### PR TITLE
threadstore: new metadata testsuite & bugfix inmem metadata book

### DIFF
--- a/test/metadata_suite.go
+++ b/test/metadata_suite.go
@@ -1,0 +1,160 @@
+package test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/textileio/go-textile-core/thread"
+	tstore "github.com/textileio/go-textile-core/threadstore"
+)
+
+const (
+	errStrNotFoundKey      = "should return nil without errors"
+	errStrPut              = "put failed for key %s: %v"
+	errStrGet              = "get failed for key %s: %v"
+	errStrValueMatch       = "expected %v, got %v"
+	errStrValueShouldExist = "value should exist for key"
+)
+
+var metadataBookSuite = map[string]func(mb tstore.ThreadMetadata) func(*testing.T){
+	"Int64":    testMetadataBookInt64,
+	"String":   testMetadataBookString,
+	"Byte":     testMetadataBookBytes,
+	"NotFound": testMetadataBookNotFound,
+}
+
+type MetadataBookFactory func() (tstore.ThreadMetadata, func())
+
+func MetadataBookTest(t *testing.T, factory MetadataBookFactory) {
+	for name, test := range metadataBookSuite {
+		mb, closeFunc := factory()
+		t.Run(name, test(mb))
+		if closeFunc != nil {
+			closeFunc()
+		}
+	}
+}
+
+func testMetadataBookInt64(mb tstore.ThreadMetadata) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Run("Put&Get", func(t *testing.T) {
+			t.Parallel()
+			tid := thread.NewIDV1(thread.Raw, 24)
+
+			key, value := "key1", int64(42)
+			if err := mb.PutInt64(tid, key, value); err != nil {
+				t.Fatalf(errStrPut, key, err)
+			}
+			v, err := mb.GetInt64(tid, key)
+			if err != nil {
+				t.Fatalf(errStrGet, key, err)
+			}
+			if v == nil {
+				t.Fatalf(errStrValueShouldExist)
+			}
+			if *v != value {
+
+				t.Fatalf(errStrValueMatch, value, v)
+			}
+		})
+	}
+}
+
+func testMetadataBookString(mb tstore.ThreadMetadata) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Run("Put&Get", func(t *testing.T) {
+			t.Parallel()
+			tid := thread.NewIDV1(thread.Raw, 24)
+
+			key, value := "key1", "textile"
+			if err := mb.PutString(tid, key, value); err != nil {
+				t.Fatalf(errStrPut, key, err)
+			}
+			v, err := mb.GetString(tid, key)
+			if err != nil {
+				t.Fatalf(errStrGet, key, err)
+			}
+			if v == nil {
+				t.Fatalf(errStrValueShouldExist)
+			}
+			if *v != value {
+
+				t.Fatalf(errStrValueMatch, value, v)
+			}
+		})
+	}
+}
+
+func testMetadataBookBytes(mb tstore.ThreadMetadata) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Run("Put&Get", func(t *testing.T) {
+			t.Parallel()
+			tid := thread.NewIDV1(thread.Raw, 24)
+
+			key, value := "key1", []byte("textile")
+			if err := mb.PutBytes(tid, key, value); err != nil {
+				t.Fatalf(errStrPut, key, err)
+			}
+			v, err := mb.GetBytes(tid, key)
+			if err != nil {
+				t.Fatalf(errStrGet, key, err)
+			}
+			if v == nil {
+				t.Fatalf(errStrValueShouldExist)
+			}
+			if !bytes.Equal(*v, value) {
+				t.Fatalf(errStrValueMatch, value, v)
+			}
+		})
+		t.Run("Immutable Put", func(t *testing.T) {
+			t.Parallel()
+			tid := thread.NewIDV1(thread.Raw, 24)
+
+			key, value := "key1", []byte("textile")
+			if err := mb.PutBytes(tid, key, value); err != nil {
+				t.Fatalf(errStrPut, key, err)
+			}
+			insertedValue := append(value[:0:0], value...)
+			value[0] = byte('T')
+			v, err := mb.GetBytes(tid, key)
+			if err != nil {
+				t.Fatalf(errStrGet, key, err)
+			}
+			if v == nil {
+				t.Fatalf(errStrValueShouldExist)
+			}
+			if !bytes.Equal(*v, insertedValue) {
+				t.Fatalf(errStrValueMatch, value, v)
+			}
+		})
+	}
+}
+
+func testMetadataBookNotFound(mb tstore.ThreadMetadata) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Run("Int64", func(t *testing.T) {
+			t.Parallel()
+			tid := thread.NewIDV1(thread.Raw, 24)
+
+			if v, err := mb.GetInt64(tid, "textile"); v != nil || err != nil {
+				t.Fatalf(errStrNotFoundKey)
+			}
+		})
+		t.Run("String", func(t *testing.T) {
+			t.Parallel()
+			tid := thread.NewIDV1(thread.Raw, 24)
+
+			if v, err := mb.GetInt64(tid, "textile"); v != nil || err != nil {
+				t.Fatalf(errStrNotFoundKey)
+			}
+		})
+		t.Run("Bytes", func(t *testing.T) {
+			t.Parallel()
+			tid := thread.NewIDV1(thread.Raw, 24)
+
+			if v, err := mb.GetInt64(tid, "textile"); v != nil || err != nil {
+				t.Fatalf(errStrNotFoundKey)
+			}
+		})
+	}
+}

--- a/tstoreds/ds_test.go
+++ b/tstoreds/ds_test.go
@@ -61,6 +61,15 @@ func TestDatastoreHeadBook(t *testing.T) {
 	}
 }
 
+func TestDatastoreMetadataBook(t *testing.T) {
+	for name, dsFactory := range dstores {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			pt.MetadataBookTest(t, metadataBookFactory(t, dsFactory))
+		})
+	}
+}
+
 func addressBookFactory(tb testing.TB, storeFactory datastoreFactory, opts Options) pt.AddrBookFactory {
 	return func() (tstore.AddrBook, func()) {
 		store, closeFunc := storeFactory(tb)
@@ -98,6 +107,17 @@ func headBookFactory(tb testing.TB, storeFactory datastoreFactory) pt.HeadBookFa
 			closeFunc()
 		}
 		return hb, closer
+	}
+}
+
+func metadataBookFactory(tb testing.TB, storeFactory datastoreFactory) pt.MetadataBookFactory {
+	return func() (tstore.ThreadMetadata, func()) {
+		store, closeFunc := storeFactory(tb)
+		tm := NewThreadMetadata(store)
+		closer := func() {
+			closeFunc()
+		}
+		return tm, closer
 	}
 }
 

--- a/tstoremem/inmem_test.go
+++ b/tstoremem/inmem_test.go
@@ -32,6 +32,12 @@ func TestInMemoryHeadBook(t *testing.T) {
 	})
 }
 
+func TestInMemoryMetadataBook(t *testing.T) {
+	pt.MetadataBookTest(t, func() (tstore.ThreadMetadata, func()) {
+		return m.NewThreadMetadata(), nil
+	})
+}
+
 func BenchmarkInMemoryThreadstore(b *testing.B) {
 	pt.BenchmarkThreadstore(b, func() (tstore.Threadstore, func()) {
 		return m.NewThreadstore(), nil

--- a/tstoremem/metadata.go
+++ b/tstoremem/metadata.go
@@ -35,7 +35,10 @@ func (ts *memoryThreadMetadata) PutInt64(t thread.ID, key string, val int64) err
 }
 
 func (ts *memoryThreadMetadata) GetInt64(t thread.ID, key string) (*int64, error) {
-	val := ts.getValue(t, key).(int64)
+	val, ok := ts.getValue(t, key).(int64)
+	if !ok {
+		return nil, nil
+	}
 	return &val, nil
 }
 
@@ -45,7 +48,10 @@ func (ts *memoryThreadMetadata) PutString(t thread.ID, key string, val string) e
 }
 
 func (ts *memoryThreadMetadata) GetString(t thread.ID, key string) (*string, error) {
-	val := ts.getValue(t, key).(string)
+	val, ok := ts.getValue(t, key).(string)
+	if !ok {
+		return nil, nil
+	}
 	return &val, nil
 }
 
@@ -57,7 +63,10 @@ func (ts *memoryThreadMetadata) PutBytes(t thread.ID, key string, val []byte) er
 }
 
 func (ts *memoryThreadMetadata) GetBytes(t thread.ID, key string) (*[]byte, error) {
-	val := ts.getValue(t, key).([]byte)
+	val, ok := ts.getValue(t, key).([]byte)
+	if !ok {
+		return nil, nil
+	}
 	return &val, nil
 }
 


### PR DESCRIPTION
Fixes #23 

When executing the test, I realized that the inmem metadata book wasn't working correctly when getting non-existent keys. So, kind of already paid off. :)

@sanderpick, these changes are parallel to existing PR, so I'll leave it to your preference when to merge it. Leaving it here if the fixed bug may be bothering some tests. 