### PR TITLE
[WIP] Dispatcher

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -1,0 +1,128 @@
+package dispatcher
+
+import (
+	"sync"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/query"
+	dispatch "github.com/textileio/go-textile-core/dispatcher"
+)
+
+// Token is a simple unique ID used to reference a registered callback.
+type Token uint
+
+// lastID is the last ID used by the singleton Dispatcher.
+var lastID uint
+
+const (
+	// ErrPersistence means that a write to the underlying event store failed.
+	ErrPersistence = esError("persistance failure")
+	// ErrTokenNotFound means the given token was not found in the dispatcher's reducer map.
+	ErrTokenNotFound = esError("token not found")
+)
+
+type esError string
+
+func (e esError) Error() string { return string(e) }
+
+// Dispatcher is used to dispatch events to registered reducers.
+//
+// This is different from generic pub-sub systems because reducers are not subscribed to particular events.
+// Every event is dispatched to every registered reducer. When a given reducer is registered, it returns a `token`,
+// which can be used to deregister the reducer later. The dispatcher wraps an underlying event store, which it uses to
+// persist events before dispatching to registered reducers. The whole system uses a mutex to prevent additional
+// dispatch calls from kicking off reducers until all in-flight reducers complete.
+type Dispatcher struct {
+	store    datastore.Datastore
+	reducers map[Token]dispatch.Reducer
+	lock     sync.Mutex
+}
+
+// NewDispatcher returns a new Dispatcher. This should only be called once in an application to ensure a singleton
+// dispatcher. While it is not enforced here, it is a good idea to a singleton pattern in your own code, for example:
+// 	var (
+// 		once sync.Once
+// 		instance *Dispatcher
+// 	)
+// 	var store = ...
+//
+//	func GetDispatcher() *Dispatcher {
+// 		once.Do(func() {
+// 			singleton = NewDispatcher(store)
+// 		})
+// 		return singleton
+// 	}
+func NewDispatcher(store datastore.Datastore) *Dispatcher {
+	return &Dispatcher{
+		store:    store,
+		reducers: make(map[Token]dispatch.Reducer),
+	}
+}
+
+// Register takes a reducer to be invoked with each dispatched event and returns a token for de-registration.
+func (d *Dispatcher) Register(reducer dispatch.Reducer) Token {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	lastID++
+	id := Token(lastID)
+	d.reducers[id] = reducer
+	return id
+}
+
+// Deregister removes a reducer based on its token. If the token is invalid (i.e. no associated reducer),
+// this is a no-op.
+func (d *Dispatcher) Deregister(token Token) error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	if _, ok := d.reducers[token]; !ok {
+		return ErrTokenNotFound
+	}
+	delete(d.reducers, token)
+	return nil
+}
+
+// Dispatch dispatches a payload to all registered reducers. It returns a multierror object, which may contain
+// zero (nil) or more errors. Errors from reducer callbacks can be safely ignored and/or retried (and are prefixed
+// with "warning"), whereas errors due to event persistence are "critical" and will be prefixed as such.
+func (d *Dispatcher) Dispatch(event dispatch.Event) error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	var result *multierror.Error
+	// Key format: <timestamp>/<entity-id>/<type>
+	// @todo: This is up for debate, its a 'fake' Event struct right now anyway
+	key := datastore.NewKey(string(event.Time())).ChildString(event.EntityID()).ChildString(event.Type())
+	// Add an Event's body to the event store as the value
+	if err := d.store.Put(key, event.Body()); err != nil {
+		return ErrPersistence
+	}
+	// Fire off reducers now that event is safely persisted
+	wg := sync.WaitGroup{}
+	wg.Add(len(d.reducers))
+	errChan := make(chan error, len(d.reducers))
+	for _, reducer := range d.reducers {
+		// Launch each reducer in a separate goroutine and send back errors
+		go func(r dispatch.Reducer) {
+			defer wg.Done()
+			if err := r.Reduce(event); err != nil {
+				errChan <- multierror.Prefix(err, "warning")
+			}
+		}(reducer)
+	}
+	wg.Wait()
+	// Close and then read from error channel to put into multierror
+	close(errChan)
+	for err := range errChan {
+		result = multierror.Append(result, err)
+	}
+	if result != nil {
+		return result.ErrorOrNil()
+	}
+	return nil
+}
+
+// Query searches the internal event store and returns a query result. This is a proxy to the underlying event store's
+// Query method.
+func (d *Dispatcher) Query(query query.Query) (query.Results, error) {
+	return d.store.Query(query)
+}

--- a/dispatcher/dispatcher_test.go
+++ b/dispatcher/dispatcher_test.go
@@ -1,0 +1,199 @@
+package dispatcher
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/query"
+	dispatch "github.com/textileio/go-textile-core/dispatcher"
+)
+
+type nullReducer struct{}
+
+func (n *nullReducer) Reduce(event dispatch.Event) error {
+	return nil
+}
+
+type errorReducer struct{}
+
+func (n *errorReducer) Reduce(event dispatch.Event) error {
+	return errors.New("error")
+}
+
+type slowReducer struct{}
+
+func (n *slowReducer) Reduce(event dispatch.Event) error {
+	time.Sleep(2 * time.Second)
+	return nil
+}
+
+type nullEvent struct {
+	Timestamp time.Time
+}
+
+func (n *nullEvent) Body() []byte {
+	return nil
+}
+
+func (n *nullEvent) Time() []byte {
+	t := n.Timestamp.UnixNano()
+	buf := new(bytes.Buffer)
+	// Use big endian to preserve lexicographic sorting
+	binary.Write(buf, binary.BigEndian, t)
+	return buf.Bytes()
+}
+
+func (n *nullEvent) EntityID() string {
+	return "null"
+}
+
+func (n *nullEvent) Type() string {
+	return "null"
+}
+
+type ErrorMapDatastore struct {
+	*datastore.MapDatastore
+}
+
+func (m *ErrorMapDatastore) Put(key datastore.Key, value []byte) error {
+	return errors.New("error")
+}
+
+// Sanity check
+var _ dispatch.Event = (*nullEvent)(nil)
+
+func setup() *Dispatcher {
+	return NewDispatcher(datastore.NewMapDatastore())
+}
+
+func TestNewDispatcher(t *testing.T) {
+	invalid := &Dispatcher{}
+	if invalid.store != nil {
+		t.Error("nil store expected")
+	}
+	if invalid.reducers != nil {
+		t.Error("nil map expected")
+	}
+	dispatcher := setup()
+	event := &nullEvent{Timestamp: time.Now()}
+	dispatcher.Dispatch(event)
+	if dispatcher.store == nil {
+		t.Error("expected valid store")
+	}
+	if dispatcher.reducers == nil {
+		t.Error("expected valid map")
+	}
+}
+
+func TestRegister(t *testing.T) {
+	dispatcher := setup()
+	token := dispatcher.Register(&nullReducer{})
+	if token != 1 {
+		t.Error("callback registration failed")
+	}
+	if len(dispatcher.reducers) < 1 {
+		t.Error("expected callbacks map to have non-zero length")
+	}
+}
+
+func TestDeregister(t *testing.T) {
+	dispatcher := setup()
+	err := dispatcher.Deregister(99)
+	if err == nil {
+		t.Error("expected to throw error")
+	}
+	if err.Error() != "token not found" {
+		t.Error("expected token now found error")
+	}
+	token := dispatcher.Register(&nullReducer{})
+	dispatcher.Deregister(token)
+	if len(dispatcher.reducers) > 0 {
+		t.Error("expected reducers map to have zero length")
+	}
+}
+
+func TestDispatch(t *testing.T) {
+	dispatcher := setup()
+	event := &nullEvent{Timestamp: time.Now()}
+	if err := dispatcher.Dispatch(event); err != nil {
+		t.Error("unexpected error in dispatch call")
+	}
+	dispatcher.Register(&errorReducer{})
+	err := dispatcher.Dispatch(event)
+	if errs, ok := err.(*multierror.Error); ok {
+		if len(errs.Errors) != 1 {
+			t.Error("should be one error")
+		}
+		if errs.Errors[0].Error() != "warning error" {
+			t.Errorf("`%s` should be `warning error`", err)
+		}
+	} else {
+		t.Error("expected error in dispatch call")
+	}
+}
+
+func TestPersistError(t *testing.T) {
+	dispatcher := NewDispatcher(&ErrorMapDatastore{
+		datastore.NewMapDatastore(),
+	})
+	event := &nullEvent{Timestamp: time.Now()}
+	dispatcher.Register(&errorReducer{})
+	dispatcher.Register(&errorReducer{})
+	err := dispatcher.Dispatch(event)
+	if err != ErrPersistence {
+		t.Error("expected persistence error")
+	}
+}
+
+func TestLock(t *testing.T) {
+	dispatcher := setup()
+	dispatcher.Register(&slowReducer{})
+	event := &nullEvent{Timestamp: time.Now()}
+	t1 := time.Now()
+	wg := &sync.WaitGroup{}
+	go func() {
+		wg.Add(1)
+		defer wg.Done()
+		if err := dispatcher.Dispatch(event); err != nil {
+			t.Error("unexpected error in dispatch call")
+		}
+	}()
+	if err := dispatcher.Dispatch(event); err != nil {
+		t.Error("unexpected error in dispatch call")
+	}
+	wg.Wait()
+	t2 := time.Now()
+	if t2.Sub(t1) < (4 * time.Second) {
+		t.Error("reached this point too soon")
+	}
+}
+
+func TestQuery(t *testing.T) {
+	dispatcher := setup()
+	var events []dispatch.Event
+	n := 100
+	for i := 1; i <= n; i++ {
+		events = append(events, &nullEvent{Timestamp: time.Now()})
+		time.Sleep(time.Millisecond)
+	}
+	for _, event := range events {
+		if err := dispatcher.Dispatch(event); err != nil {
+			t.Error("unexpected error in dispatch call")
+		}
+	}
+	results, err := dispatcher.Query(query.Query{
+		Orders: []query.Order{query.OrderByKey{}},
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if rest, _ := results.Rest(); len(rest) != n {
+		t.Errorf("expected %d result, got %d", n, len(rest))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/gogo/protobuf v1.3.0
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/golang-lru v0.5.3
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,10 @@ github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvK
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
+github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8Bppgk=
@@ -377,6 +381,8 @@ github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFd
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/textileio/go-textile-core v0.0.0-20191015153302-09f58f138ff2 h1:89IXwsxVwcwmNd59bxDo0dSwrNQbHhpyEAwWWNvIk44=
 github.com/textileio/go-textile-core v0.0.0-20191015153302-09f58f138ff2/go.mod h1:7Agpsfm5EoM4Qpd6MVSR61mklARurC1JQMjJ/sn6ooo=
+github.com/textileio/go-textile-core v0.0.0-20191016171609-e984eef83a4c h1:ceJlIzojwCtDaDYJFOyzzWiu4htbdo6DVPYKI8SwNiM=
+github.com/textileio/go-textile-core v0.0.0-20191016220101-ae46e632fcf0 h1:jFHvJZ6SfA7pJMDT9D/m2vBkJ+zc/0eAnBfWt7Ircqo=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436 h1:qOpVTI+BrstcjTZLm2Yz/3sOnqkzj3FQoh0g+E5s3Gc=
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=


### PR DESCRIPTION
### Issue or RFC Endorsed by Textile's Maintainers

Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

### Description of the Change

This PR consolidates some early draft code into a more cohesive (simpler) dispatcher framework. It is based around the idea of a singleton dispatcher, which persists and dispatches events, one at a time. The dispatcher blocks until a given event has been completely 'handled', which includes all registered callbacks. From discussions with the team on Slack, it because clear that some of the transactional behavior that we had initially planned is less critical, and could be mostly handled with a simple mutex. Then, waiting for reducers (which are each run concurrently) was greatly simplified. Additionally, some nice 'nice to have' features (like multiple errors being returned etc) were added for completeness thanks to @jsign. We have 100% test coverage, and while the interfaces are likely to change still, this provides a good base upon which to start.

Depends on https://github.com/textileio/go-textile-core/pull/18.

### Alternate Designs

There were a lot of alternative options here, include a more pub/sub style system (see #17 for an example), but this implementation covers most of the anticipated uses we have at the moment. It doesn't really address _consumers_ at this stage, but that isn't really the point here anyway.

### Possible Drawbacks

This is a bit more complicated than just leaving all the concurrency up to a third-party database, but what we add in complexity, I think we gain in flexibility. Additionally, we leave a lot of flexibility and power up to the reducers here, so the effectiveness of this code does rely to some degree on the effectiveness of the registered reduces. It is hard to strictly enforce good behavior this way, but... developer beware!

### Verification Process

New tests were added to verify the new features are doing what they claim to be doing. We have 100% test coverage, which is a great place to start from.

### Release Notes

Added a dispatcher framework with well-defined reducer handling and flexible underlying event store requirements. Test coverage for dispatcher starts at 100%.