### PR TITLE
Shell: Improve thread visibility

### DIFF
--- a/exe/daemon/main.go
+++ b/exe/daemon/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	logging "github.com/ipfs/go-log"
 	"github.com/libp2p/go-libp2p-core/host"
 	kaddht "github.com/libp2p/go-libp2p-kad-dht"
 	tserv "github.com/textileio/go-textile-core/threadservice"
@@ -14,17 +15,17 @@ var (
 	dht *kaddht.IpfsDHT
 	api tserv.Threadservice
 
-	bootstrapPeers = []string{
-		"/ip4/104.210.43.77/tcp/4001/ipfs/12D3KooWSdGmRz5JQidqrtmiPGVHkStXpbSAMnbCcW8abq6zuiDP", // us-west
-		"/ip4/20.39.232.27/tcp/4001/ipfs/12D3KooWLnUv9MWuRM6uHirRPBM4NwRj54n4gNNnBtiFiwPiv3Up",  // eu-west
-		"/ip4/34.87.103.105/tcp/4001/ipfs/12D3KooWA5z2C3z1PNKi36Bw1MxZhBD8nv7UbB7YQP6WcSWYNwRQ", // as-southeast
-	}
+	log = logging.Logger("shell")
 )
 
 func main() {
+	if err := logging.SetLogLevel("daemon", "debug"); err != nil {
+		panic(err)
+	}
+
 	var cancel context.CancelFunc
 	var h host.Host
-	_, cancel, _, h, dht, api = util.Build(bootstrapPeers)
+	_, cancel, _, h, dht, api = util.Build()
 
 	defer cancel()
 	defer h.Close()
@@ -33,6 +34,8 @@ func main() {
 
 	fmt.Println("Welcome to Threads!")
 	fmt.Println("Your peer ID is " + h.ID().String())
+
+	log.Debug("daemon started")
 
 	select {}
 }

--- a/exe/util/util.go
+++ b/exe/util/util.go
@@ -27,8 +27,15 @@ import (
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
+// BootstrapPeers to bootstrap from.
+var bootstrapPeers = []string{
+	"/ip4/104.210.43.77/tcp/4001/ipfs/12D3KooWSdGmRz5JQidqrtmiPGVHkStXpbSAMnbCcW8abq6zuiDP", // us-west
+	"/ip4/20.39.232.27/tcp/4001/ipfs/12D3KooWLnUv9MWuRM6uHirRPBM4NwRj54n4gNNnBtiFiwPiv3Up",  // eu-west
+	"/ip4/34.87.103.105/tcp/4001/ipfs/12D3KooWA5z2C3z1PNKi36Bw1MxZhBD8nv7UbB7YQP6WcSWYNwRQ", // as-southeast
+}
+
 // Build an instance of threads.
-func Build(bootpeers []string) (
+func Build() (
 	ctx context.Context,
 	cancel context.CancelFunc,
 	ds datastore.Batching,
@@ -97,11 +104,10 @@ func Build(bootpeers []string) (
 	}
 
 	// Bootstrap to textile peers
-	err = logging.SetLogLevel("ipfslite", "debug")
-	if err != nil {
+	if err = logging.SetLogLevel("ipfslite", "debug"); err != nil {
 		panic(err)
 	}
-	boots, err := ParseBootstrapPeers(bootpeers)
+	boots, err := ParseBootstrapPeers(bootstrapPeers)
 	if err != nil {
 		panic(err)
 	}

--- a/threads.go
+++ b/threads.go
@@ -136,6 +136,7 @@ func (t *threads) Host() host.Host {
 	return t.host
 }
 
+// Store returns the threadstore.
 func (t *threads) Store() tstore.Threadstore {
 	return t.store
 }
@@ -254,6 +255,10 @@ func (t *threads) AddFollower(ctx context.Context, id thread.ID, pid peer.ID) er
 	if err != nil {
 		return err
 	}
+	if info.Logs.Len() == 0 {
+		return fmt.Errorf("thread not found")
+	}
+
 	for _, l := range info.Logs {
 		if err = t.service.pushLog(ctx, id, l, pid); err != nil {
 			return err


### PR DESCRIPTION
Adds some more niceties to the shell:
- Changes the command paradigm so that you can see output from all threads
- "Enter" a thread with `:enter` such that you can type messages as before
- You can always type a message to a specific thread by prefixing the name: `:team hey!`
- "Exit" a thread with exit 
- Stack commands like `:team:address` (show team's addresses)
- Use `:help` to see available commands