### PR TITLE
WebSocket Server

### DIFF
--- a/exe/daemon/main.go
+++ b/exe/daemon/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 
 	logging "github.com/ipfs/go-log"
@@ -19,13 +20,17 @@ var (
 )
 
 func main() {
+	repo := flag.String("repo", ".threads", "repo location")
+	port := flag.Int("port", 4006, "host port")
+	flag.Parse()
+
 	if err := logging.SetLogLevel("daemon", "debug"); err != nil {
 		panic(err)
 	}
 
 	var cancel context.CancelFunc
 	var h host.Host
-	_, cancel, _, h, dht, api = util.Build(true)
+	_, cancel, _, h, dht, api = util.Build(*repo, *port, true)
 
 	defer cancel()
 	defer h.Close()

--- a/exe/shell/main.go
+++ b/exe/shell/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/peerstore"
+	pstore "github.com/libp2p/go-libp2p-core/peerstore"
 	kaddht "github.com/libp2p/go-libp2p-kad-dht"
 	swarm "github.com/libp2p/go-libp2p-swarm"
 	"github.com/libp2p/go-libp2p/p2p/discovery"
@@ -62,6 +63,12 @@ type msg struct {
 	Txt string
 }
 
+type notifee struct{}
+
+func (n *notifee) HandlePeerFound(p peer.AddrInfo) {
+	api.Host().Peerstore().AddAddrs(p.ID, p.Addrs, pstore.ConnectedAddrTTL)
+}
+
 func main() {
 	if err := logging.SetLogLevel("shell", "debug"); err != nil {
 		panic(err)
@@ -82,6 +89,7 @@ func main() {
 		panic(err)
 	}
 	defer mdns.Close()
+	mdns.RegisterNotifee(&notifee{})
 
 	// Start the prompt
 	fmt.Println(grey("Welcome to Threads!"))

--- a/exe/util/util.go
+++ b/exe/util/util.go
@@ -19,6 +19,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	kaddht "github.com/libp2p/go-libp2p-kad-dht"
+	"github.com/libp2p/go-libp2p-peerstore/pstoreds"
 	"github.com/mitchellh/go-homedir"
 	ma "github.com/multiformats/go-multiaddr"
 	tserv "github.com/textileio/go-textile-core/threadservice"
@@ -63,6 +64,10 @@ func Build(debug bool) (
 	if err != nil {
 		panic(err)
 	}
+	pstore, err := pstoreds.NewPeerstore(ctx, ds, pstoreds.DefaultOpts())
+	if err != nil {
+		panic(err)
+	}
 
 	listen, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", *port))
 	if err != nil {
@@ -75,6 +80,7 @@ func Build(debug bool) (
 		nil,
 		[]ma.Multiaddr{listen},
 		libp2p.ConnectionManager(connmgr.NewConnManager(100, 400, time.Minute)),
+		libp2p.Peerstore(pstore),
 	)
 	if err != nil {
 		panic(err)

--- a/exe/util/util.go
+++ b/exe/util/util.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -36,18 +35,15 @@ var bootstrapPeers = []string{
 }
 
 // Build an instance of threads.
-func Build(debug bool) (
+func Build(repo string, port int, debug bool) (
 	ctx context.Context,
 	cancel context.CancelFunc,
 	ds datastore.Batching,
 	h host.Host,
 	dht *kaddht.IpfsDHT,
 	api tserv.Threadservice) {
-	repo := flag.String("repo", ".threads", "repo location")
-	port := flag.Int("port", 4006, "host port")
-	flag.Parse()
 
-	repop, err := homedir.Expand(*repo)
+	repop, err := homedir.Expand(repo)
 	if err != nil {
 		panic(err)
 	}
@@ -69,7 +65,7 @@ func Build(debug bool) (
 		panic(err)
 	}
 
-	listen, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", *port))
+	listen, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", port))
 	if err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gogo/protobuf v1.3.0
 	github.com/gogo/status v1.1.0
 	github.com/google/uuid v1.1.1
+	github.com/gorilla/websocket v1.4.1
 	github.com/hashicorp/golang-lru v0.5.3
 	github.com/hsanjuan/ipfs-lite v0.1.6
 	github.com/improbable-eng/grpc-web v0.11.0

--- a/test/threads_suite.go
+++ b/test/threads_suite.go
@@ -34,10 +34,10 @@ var threadsSuite = map[string]func(tserv.Threadservice, tserv.Threadservice) fun
 func ThreadsTest(t *testing.T) {
 	for name, test := range threadsSuite {
 		// Create two thread services.
-		m1, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/10000")
-		ts1 := newService(t, m1)
-		m2, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/10001")
-		ts2 := newService(t, m2)
+		m1, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/4006")
+		ts1 := newService(t, m1, "127.0.0.1:5050")
+		m2, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/4007")
+		ts2 := newService(t, m2, "127.0.0.1:5051")
 
 		ts1.Host().Peerstore().AddAddrs(ts2.Host().ID(), ts2.Host().Addrs(), peerstore.PermanentAddrTTL)
 		ts2.Host().Peerstore().AddAddrs(ts1.Host().ID(), ts1.Host().Addrs(), peerstore.PermanentAddrTTL)
@@ -47,7 +47,7 @@ func ThreadsTest(t *testing.T) {
 	}
 }
 
-func newService(t *testing.T, listen ma.Multiaddr) tserv.Threadservice {
+func newService(t *testing.T, listen ma.Multiaddr, proxyAddr string) tserv.Threadservice {
 	sk, _, err := ic.GenerateKeyPair(ic.Ed25519, 0)
 	check(t, err)
 	host, err := libp2p.New(
@@ -65,7 +65,7 @@ func newService(t *testing.T, listen ma.Multiaddr) tserv.Threadservice {
 		bsrv.Blockstore(),
 		dag.NewDAGService(bsrv),
 		tstore.NewThreadstore(),
-		threads.Options{Debug: true})
+		threads.Options{ProxyAddr: proxyAddr, Debug: true})
 	check(t, err)
 	return ts
 }

--- a/threads.go
+++ b/threads.go
@@ -2,7 +2,6 @@ package threads
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
@@ -720,10 +719,7 @@ func (t *threads) broadcast(r tserv.Record) error {
 		return err
 	}
 
-	data := r.Value().RawData()
-	encoded := make([]byte, base64.StdEncoding.EncodedLen(len(data)))
-	base64.StdEncoding.Encode(encoded, data)
-	t.ws.Send(encoded)
+	t.ws.Send(r)
 	return nil
 }
 

--- a/ws/client.go
+++ b/ws/client.go
@@ -1,0 +1,143 @@
+package ws
+
+import (
+	"bytes"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	// Time allowed to write a message to the peer.
+	writeWait = 10 * time.Second
+
+	// Time allowed to read the next pong message from the peer.
+	pongWait = 60 * time.Second
+
+	// Send pings to peer with this period. Must be less than pongWait.
+	pingPeriod = (pongWait * 9) / 10
+
+	// Maximum message size allowed from peer.
+	maxMessageSize = 512
+)
+
+var (
+	upgrader = websocket.Upgrader{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+		CheckOrigin: func(r *http.Request) bool {
+			// @todo: auth with follow and/or read key
+			return true
+		},
+	}
+
+	newline = []byte{'\n'}
+	space   = []byte{' '}
+)
+
+// Client is a middleman between the websocket connection and the hub.
+type Client struct {
+	hub *Hub
+
+	// The websocket connection.
+	conn *websocket.Conn
+
+	// Buffered channel of outbound messages.
+	send chan []byte
+}
+
+// readPump pumps messages from the websocket connection to the hub.
+//
+// The application runs readPump in a per-connection goroutine. The application
+// ensures that there is at most one reader on a connection by executing all
+// reads from this goroutine.
+func (c *Client) readPump() {
+	defer func() {
+		c.hub.unregister <- c
+		c.conn.Close()
+	}()
+	c.conn.SetReadLimit(maxMessageSize)
+	_ = c.conn.SetReadDeadline(time.Now().Add(pongWait))
+	c.conn.SetPongHandler(func(string) error {
+		_ = c.conn.SetReadDeadline(time.Now().Add(pongWait))
+		return nil
+	})
+	for {
+		_, message, err := c.conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(
+				err,
+				websocket.CloseGoingAway,
+				websocket.CloseAbnormalClosure) {
+				log.Errorf("error: %v", err)
+			}
+			break
+		}
+		message = bytes.TrimSpace(bytes.Replace(message, newline, space, -1))
+		// @todo: don't echo message—it should hit AddRecord instead
+		c.hub.broadcast <- message
+	}
+}
+
+// writePump pumps messages from the hub to the websocket connection.
+//
+// A goroutine running writePump is started for each connection. The
+// application ensures that there is at most one writer to a connection by
+// executing all writes from this goroutine.
+func (c *Client) writePump() {
+	ticker := time.NewTicker(pingPeriod)
+	defer func() {
+		ticker.Stop()
+		c.conn.Close()
+	}()
+	for {
+		select {
+		case message, ok := <-c.send:
+			_ = c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if !ok {
+				// The hub closed the channel.
+				_ = c.conn.WriteMessage(websocket.CloseMessage, []byte{})
+				return
+			}
+
+			w, err := c.conn.NextWriter(websocket.TextMessage)
+			if err != nil {
+				return
+			}
+			_, _ = w.Write(message)
+
+			// Add queued chat messages to the current websocket message.
+			n := len(c.send)
+			for i := 0; i < n; i++ {
+				_, _ = w.Write(newline)
+				_, _ = w.Write(<-c.send)
+			}
+
+			if err := w.Close(); err != nil {
+				return
+			}
+		case <-ticker.C:
+			_ = c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// serveWs handles websocket requests from the peer.
+func serveWs(hub *Hub, w http.ResponseWriter, r *http.Request) {
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	client := &Client{hub: hub, conn: conn, send: make(chan []byte, 256)}
+	client.hub.register <- client
+
+	// Allow collection of memory referenced by the caller by doing all work in
+	// new goroutines.
+	go client.writePump()
+	go client.readPump()
+}

--- a/ws/client.go
+++ b/ws/client.go
@@ -1,3 +1,5 @@
+// Inspired by https://github.com/gorilla/websocket/tree/master/examples/chat with
+// adaptations for multiple rooms ("threads" in Textile parlance) and authentication.
 package ws
 
 import (
@@ -112,6 +114,7 @@ func (c *Client) readPump() {
 // A goroutine running writePump is started for each connection. The
 // application ensures that there is at most one writer to a connection by
 // executing all writes from this goroutine.
+// @todo: Handle write errors.
 func (c *Client) writePump() {
 	ticker := time.NewTicker(pingPeriod)
 	defer func() {

--- a/ws/hub.go
+++ b/ws/hub.go
@@ -1,0 +1,80 @@
+/*		BSD 2-Clause "Simplified" License
+
+		Copyright (c) 2013 The Gorilla WebSocket Authors. All rights reserved.
+
+		Redistribution and use in source and binary forms, with or without
+		modification, are permitted provided that the following conditions are met:
+
+		  Redistributions of source code must retain the above copyright notice, this
+		  list of conditions and the following disclaimer.
+
+		  Redistributions in binary form must reproduce the above copyright notice,
+		  this list of conditions and the following disclaimer in the documentation
+		  and/or other materials provided with the distribution.
+
+		THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+		ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+		WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+		DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+		FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+		DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+		SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+		CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+		OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+		OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+// Inspired by https://github.com/gorilla/websocket/tree/master/examples/chat with
+// adaptations for multiple rooms ("threads" in Textile parlance).
+package ws
+
+// Hub maintains the set of active clients and broadcasts messages to the
+// clients.
+type Hub struct {
+	// clients currently registered.
+	// @todo: migrate to emtpy struct
+	// @todo: map clients to threads via thread list
+	clients map[*Client]bool
+
+	// broadcast message to clients.
+	broadcast chan []byte
+
+	// register requests from the clients.
+	register chan *Client
+
+	// unregister requests from clients.
+	unregister chan *Client
+}
+
+// NewHub creates a new client hub.
+func newHub() *Hub {
+	return &Hub{
+		broadcast:  make(chan []byte),
+		register:   make(chan *Client),
+		unregister: make(chan *Client),
+		clients:    make(map[*Client]bool),
+	}
+}
+
+// Run the hub.
+func (h *Hub) run() {
+	for {
+		select {
+		case client := <-h.register:
+			h.clients[client] = true
+		case client := <-h.unregister:
+			if _, ok := h.clients[client]; ok {
+				delete(h.clients, client)
+				close(client.send)
+			}
+		case message := <-h.broadcast:
+			for client := range h.clients {
+				select {
+				case client.send <- message:
+				default:
+					close(client.send)
+					delete(h.clients, client)
+				}
+			}
+		}
+	}
+}

--- a/ws/hub.go
+++ b/ws/hub.go
@@ -1,42 +1,21 @@
-/*		BSD 2-Clause "Simplified" License
-
-		Copyright (c) 2013 The Gorilla WebSocket Authors. All rights reserved.
-
-		Redistribution and use in source and binary forms, with or without
-		modification, are permitted provided that the following conditions are met:
-
-		  Redistributions of source code must retain the above copyright notice, this
-		  list of conditions and the following disclaimer.
-
-		  Redistributions in binary form must reproduce the above copyright notice,
-		  this list of conditions and the following disclaimer in the documentation
-		  and/or other materials provided with the distribution.
-
-		THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-		ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-		WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-		DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-		FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-		DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-		SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-		CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-		OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-		OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 // Inspired by https://github.com/gorilla/websocket/tree/master/examples/chat with
-// adaptations for multiple rooms ("threads" in Textile parlance).
+// adaptations for multiple rooms ("threads" in Textile parlance) and authentication.
 package ws
+
+import (
+	"encoding/base64"
+
+	tserv "github.com/textileio/go-textile-core/threadservice"
+)
 
 // Hub maintains the set of active clients and broadcasts messages to the
 // clients.
 type Hub struct {
 	// clients currently registered.
-	// @todo: migrate to emtpy struct
-	// @todo: map clients to threads via thread list
-	clients map[*Client]bool
+	clients map[*Client]struct{}
 
-	// broadcast message to clients.
-	broadcast chan []byte
+	// broadcast records to clients.
+	broadcast chan tserv.Record
 
 	// register requests from the clients.
 	register chan *Client
@@ -48,10 +27,10 @@ type Hub struct {
 // NewHub creates a new client hub.
 func newHub() *Hub {
 	return &Hub{
-		broadcast:  make(chan []byte),
+		broadcast:  make(chan tserv.Record),
 		register:   make(chan *Client),
 		unregister: make(chan *Client),
-		clients:    make(map[*Client]bool),
+		clients:    make(map[*Client]struct{}),
 	}
 }
 
@@ -60,16 +39,22 @@ func (h *Hub) run() {
 	for {
 		select {
 		case client := <-h.register:
-			h.clients[client] = true
+			h.clients[client] = struct{}{}
 		case client := <-h.unregister:
 			if _, ok := h.clients[client]; ok {
 				delete(h.clients, client)
 				close(client.send)
 			}
-		case message := <-h.broadcast:
+		case rec := <-h.broadcast:
+			data := rec.Value().RawData()
+			msg := make([]byte, base64.StdEncoding.EncodedLen(len(data)))
+			base64.StdEncoding.Encode(msg, data)
 			for client := range h.clients {
+				if _, ok := client.threads[rec.ThreadID()]; !ok {
+					continue
+				}
 				select {
-				case client.send <- message:
+				case client.send <- msg:
 				default:
 					close(client.send)
 					delete(h.clients, client)

--- a/ws/index.html
+++ b/ws/index.html
@@ -7,16 +7,28 @@ This is an example of a web client opening a ws connection to Threads.
     <meta charset="utf-8">
     <script>
         window.addEventListener('load', function() {
-            const socket = new WebSocket('ws://localhost:8080');
+            const socket = new WebSocket('ws://localhost:8080')
             socket.addEventListener('open', function (e) {
                 console.log('Connection started.')
-            });
+
+                // Subscribe to thread in URL query
+                let threads
+                let params = new URLSearchParams(window.location.search);
+                if (params.has('thread')) {
+                    threads = params.getAll('thread')
+                }
+                let msg = {
+                    type: 'subscribe',
+                    threads: threads
+                }
+                socket.send(JSON.stringify(msg))
+            })
             socket.addEventListener('message', function (e) {
-                console.log('Record: ', e.data);
-            });
+                console.log('Record: ', e.data)
+            })
             socket.addEventListener('error', function (e) {
-                console.error("Error: ", e);
-            });
+                console.error("Error: ", e)
+            })
         });
     </script>
     <title>Threads</title>

--- a/ws/index.html
+++ b/ws/index.html
@@ -1,0 +1,25 @@
+<!--
+This is an example of a web client opening a ws connection to Threads.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <script>
+        window.addEventListener('load', function() {
+            const socket = new WebSocket('ws://localhost:8080');
+            socket.addEventListener('open', function (e) {
+                console.log('Connection started.')
+            });
+            socket.addEventListener('message', function (e) {
+                console.log('Record: ', e.data);
+            });
+            socket.addEventListener('error', function (e) {
+                console.error("Error: ", e);
+            });
+        });
+    </script>
+    <title>Threads</title>
+</head>
+<body></body>
+</html>

--- a/ws/server.go
+++ b/ws/server.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	logging "github.com/ipfs/go-log"
+	tserv "github.com/textileio/go-textile-core/threadservice"
 )
 
 var log = logging.Logger("ws")
@@ -55,8 +56,8 @@ func NewServer(addr string) *Server {
 }
 
 // Send a message to the hub.
-func (s *Server) Send(message []byte) {
-	s.hub.broadcast <- message
+func (s *Server) Send(r tserv.Record) {
+	s.hub.broadcast <- r
 }
 
 // Close the server.

--- a/ws/server.go
+++ b/ws/server.go
@@ -1,0 +1,69 @@
+package ws
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	logging "github.com/ipfs/go-log"
+)
+
+var log = logging.Logger("ws")
+
+// Server wraps a connection hub and http server.
+type Server struct {
+	hub *Hub
+	s   *http.Server
+}
+
+// NewServer returns a web socket server.
+func NewServer(addr string) *Server {
+	s := &Server{
+		hub: newHub(),
+	}
+	go s.hub.run()
+
+	s.s = &http.Server{
+		Addr: addr,
+	}
+	s.s.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serveWs(s.hub, w, r)
+	})
+
+	errc := make(chan error)
+	go func() {
+		errc <- s.s.ListenAndServe()
+		close(errc)
+	}()
+	go func() {
+		for {
+			select {
+			case err, ok := <-errc:
+				if err != nil && err != http.ErrServerClosed {
+					log.Errorf("ws server error: %s", err)
+				}
+				if !ok {
+					log.Info("ws server was shutdown")
+					return
+				}
+			}
+		}
+	}()
+	log.Infof("ws server listening at %s", s.s.Addr)
+
+	return s
+}
+
+// Send a message to the hub.
+func (s *Server) Send(message []byte) {
+	s.hub.broadcast <- message
+}
+
+// Close the server.
+func (s *Server) Close() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := s.s.Shutdown(ctx); err != nil {
+		log.Errorf("error shutting down ws server: %s", err)
+	}
+}


### PR DESCRIPTION
Closes #55 

- Fixes `exe/util.Build` so that it uses a disc-backed peerstore.
- Registers a "notifee" for the MDNS module in the shell.
- Push records for registered threads to web socket clients. Web clients register for a list of threads. The example `index.html` file shows how you might do this from a list in the URL query params:
```
// Subscribe to thread in URL query
let threads
let params = new URLSearchParams(window.location.search);
if (params.has('thread')) {
    threads = params.getAll('thread')
}
let msg = {
    type: 'subscribe',
    threads: threads
}
socket.send(JSON.stringify(msg))
```