### PR TITLE
tests: use the same peers for all tests

### DIFF
--- a/test/threads_suite.go
+++ b/test/threads_suite.go
@@ -32,16 +32,16 @@ var threadsSuite = map[string]func(tserv.Threadservice, tserv.Threadservice) fun
 }
 
 func ThreadsTest(t *testing.T) {
+	// Create two thread services.
+	m1, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/4006")
+	ts1 := newService(t, m1, "127.0.0.1:5050")
+	m2, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/4007")
+	ts2 := newService(t, m2, "127.0.0.1:5051")
+
+	ts1.Host().Peerstore().AddAddrs(ts2.Host().ID(), ts2.Host().Addrs(), peerstore.PermanentAddrTTL)
+	ts2.Host().Peerstore().AddAddrs(ts1.Host().ID(), ts1.Host().Addrs(), peerstore.PermanentAddrTTL)
+
 	for name, test := range threadsSuite {
-		// Create two thread services.
-		m1, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/4006")
-		ts1 := newService(t, m1, "127.0.0.1:5050")
-		m2, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/4007")
-		ts2 := newService(t, m2, "127.0.0.1:5051")
-
-		ts1.Host().Peerstore().AddAddrs(ts2.Host().ID(), ts2.Host().Addrs(), peerstore.PermanentAddrTTL)
-		ts2.Host().Peerstore().AddAddrs(ts1.Host().ID(), ts1.Host().Addrs(), peerstore.PermanentAddrTTL)
-
 		// Run the test.
 		t.Run(name, test(ts1, ts2))
 	}


### PR DESCRIPTION
Closes #42 

Doh. Of course, the same peers should be used for all these thread tests OR they should be shutdown afterward. Opting for using the same here. Peers were starting up on the same port, which leads to the "connected to wrong peer" error message.