### PR TITLE
Fix up client method responses

### DIFF
--- a/exe/daemon/main.go
+++ b/exe/daemon/main.go
@@ -6,14 +6,11 @@ import (
 	"fmt"
 
 	logging "github.com/ipfs/go-log"
-	"github.com/libp2p/go-libp2p-core/host"
-	kaddht "github.com/libp2p/go-libp2p-kad-dht"
 	tserv "github.com/textileio/go-textile-core/threadservice"
 	"github.com/textileio/go-textile-threads/exe/util"
 )
 
 var (
-	dht *kaddht.IpfsDHT
 	api tserv.Threadservice
 
 	log = logging.Logger("shell")
@@ -30,16 +27,13 @@ func main() {
 	}
 
 	var cancel context.CancelFunc
-	var h host.Host
-	_, cancel, _, h, dht, api = util.Build(*repo, *port, *proxyAddr, true)
+	_, cancel, _, api = util.Build(*repo, *port, *proxyAddr, true)
 
 	defer cancel()
-	defer h.Close()
-	defer dht.Close()
 	defer api.Close()
 
 	fmt.Println("Welcome to Threads!")
-	fmt.Println("Your peer ID is " + h.ID().String())
+	fmt.Println("Your peer ID is " + api.DHT().Host().ID().String())
 
 	log.Debug("daemon started")
 

--- a/exe/daemon/main.go
+++ b/exe/daemon/main.go
@@ -20,11 +20,12 @@ func main() {
 		panic(err)
 	}
 
-	_, cancel, _, h, dht, api := util.Build(*repo, *port, *proxyAddr, true)
+	_, cancel, ds, h, dht, api := util.Build(*repo, *port, *proxyAddr, true)
 
 	defer cancel()
 	defer dht.Close()
 	defer api.Close()
+	defer ds.Close()
 
 	fmt.Println("Welcome to Threads!")
 	fmt.Println("Your peer ID is " + h.ID().String())

--- a/exe/daemon/main.go
+++ b/exe/daemon/main.go
@@ -1,20 +1,14 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 
 	logging "github.com/ipfs/go-log"
-	tserv "github.com/textileio/go-textile-core/threadservice"
 	"github.com/textileio/go-textile-threads/exe/util"
 )
 
-var (
-	api tserv.Threadservice
-
-	log = logging.Logger("shell")
-)
+var log = logging.Logger("daemon")
 
 func main() {
 	repo := flag.String("repo", ".threads", "repo location")
@@ -26,14 +20,14 @@ func main() {
 		panic(err)
 	}
 
-	var cancel context.CancelFunc
-	_, cancel, _, api = util.Build(*repo, *port, *proxyAddr, true)
+	_, cancel, _, h, dht, api := util.Build(*repo, *port, *proxyAddr, true)
 
 	defer cancel()
+	defer dht.Close()
 	defer api.Close()
 
 	fmt.Println("Welcome to Threads!")
-	fmt.Println("Your peer ID is " + api.DHT().Host().ID().String())
+	fmt.Println("Your peer ID is " + h.ID().String())
 
 	log.Debug("daemon started")
 

--- a/exe/shell/main.go
+++ b/exe/shell/main.go
@@ -38,7 +38,6 @@ import (
 var (
 	ctx      context.Context
 	ds       datastore.Batching
-	dht      *kaddht.IpfsDHT
 	api      tserv.Threadservice
 	threadID thread.ID
 
@@ -85,10 +84,10 @@ func main() {
 
 	var cancel context.CancelFunc
 	var h host.Host
+	var dht *kaddht.IpfsDHT
 	ctx, cancel, ds, h, dht, api = util.Build(*repo, *port, *proxyAddr, true)
 
 	defer cancel()
-	defer h.Close()
 	defer dht.Close()
 	defer api.Close()
 

--- a/exe/shell/main.go
+++ b/exe/shell/main.go
@@ -104,7 +104,7 @@ func main() {
 	if *wsAddr == "" {
 		*wsAddr = "0.0.0.0:8080"
 	}
-	wsServer := ws.NewServer(api, *wsAddr)
+	wsServer := ws.NewServer(ctx, api, *wsAddr)
 	defer wsServer.Close()
 	if err = logging.SetLogLevel("ws", "debug"); err != nil {
 		panic(err)
@@ -372,21 +372,13 @@ func addCmd(args []string) (out string, err error) {
 
 	var fk, rk *sym.Key
 	if len(args) > 2 {
-		fkb, err := base58.Decode(args[2])
-		if err != nil {
-			return "", err
-		}
-		fk, err = sym.NewKey(fkb)
+		fk, err = tutil.DecodeKey(args[2])
 		if err != nil {
 			return "", err
 		}
 	}
 	if len(args) > 3 {
-		rkb, err := base58.Decode(args[3])
-		if err != nil {
-			return "", err
-		}
-		rk, err = sym.NewKey(rkb)
+		rk, err = tutil.DecodeKey(args[3])
 		if err != nil {
 			return "", err
 		}

--- a/exe/shell/main.go
+++ b/exe/shell/main.go
@@ -90,6 +90,7 @@ func main() {
 	defer cancel()
 	defer dht.Close()
 	defer api.Close()
+	defer ds.Close()
 
 	// Build a MDNS service
 	mdns, err := discovery.NewMdnsService(ctx, h, time.Second, "")

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/libp2p/go-libp2p-connmgr v0.1.1
 	github.com/libp2p/go-libp2p-core v0.2.3
 	github.com/libp2p/go-libp2p-gostream v0.2.0
-	github.com/libp2p/go-libp2p-kad-dht v0.2.1
+	github.com/libp2p/go-libp2p-kad-dht v0.3.0
 	github.com/libp2p/go-libp2p-peerstore v0.1.3
 	github.com/libp2p/go-libp2p-pubsub v0.1.1
 	github.com/libp2p/go-libp2p-swarm v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -277,6 +277,8 @@ github.com/libp2p/go-libp2p-gostream v0.2.0 h1:YGLebbo8KfylSkuralCCyas/hVrgWjc+c
 github.com/libp2p/go-libp2p-gostream v0.2.0/go.mod h1:nN/Aw00orrADXaXgNCeYjCtQrk6eT20PX/G8F12NW/s=
 github.com/libp2p/go-libp2p-kad-dht v0.2.1 h1:+pb1DCkV/6oNQjTZVXl+Y++eV0rnelx/L8y1t4J+Rnw=
 github.com/libp2p/go-libp2p-kad-dht v0.2.1/go.mod h1:k7ONOlup7HKzQ68dE6lSnp07cdxdkmnRa+6B4Fh9/w0=
+github.com/libp2p/go-libp2p-kad-dht v0.3.0 h1:KUJaqW3kkHP6zcL0s1CDg+yO0NYNNPkXmG4FrnZbwzM=
+github.com/libp2p/go-libp2p-kad-dht v0.3.0/go.mod h1:7nBsfkMq2zN1qPs6n/fNopJfvmK9NZRNicRrCnwQR8o=
 github.com/libp2p/go-libp2p-kbucket v0.2.1 h1:q9Jfwww9XnXc1K9dyYuARJxJvIvhgYVaQCuziO/dF3c=
 github.com/libp2p/go-libp2p-kbucket v0.2.1/go.mod h1:/Rtu8tqbJ4WQ2KTCOMJhggMukOLNLNPY1EtEWWLxUvc=
 github.com/libp2p/go-libp2p-loggables v0.1.0 h1:h3w8QFfCt2UJl/0/NW4K829HX/0S4KD31PQ7m8UXXO8=
@@ -461,8 +463,6 @@ github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709 h1:Ko2LQMrRU+Oy
 github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
-github.com/textileio/go-textile-core v0.0.0-20191108004524-7886c90c9177 h1:kV7QLBZsJviKJnEpuJYvRJLcgDQp5QQfzwQ2Shxb+LU=
-github.com/textileio/go-textile-core v0.0.0-20191108004524-7886c90c9177/go.mod h1:F98c4NsIU30JVjGrGG4HrG1Cs2iJk2RRRcwYAhSYP7I=
 github.com/textileio/go-textile-core v0.0.0-20191112000026-958d7d17affc h1:e/kukeTe28r5tHMuRLFhHamyFAG7AeUYaPFl3rYJiOs=
 github.com/textileio/go-textile-core v0.0.0-20191112000026-958d7d17affc/go.mod h1:F98c4NsIU30JVjGrGG4HrG1Cs2iJk2RRRcwYAhSYP7I=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
@@ -565,6 +565,8 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180518175338-11a468237815/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/test/keybook_suite.go
+++ b/test/keybook_suite.go
@@ -192,12 +192,17 @@ func testKeyBookLogs(kb tstore.KeyBook) func(t *testing.T) {
 		if err != nil {
 			t.Fatalf("getting logs with keys failed: %v", err)
 		}
-		sort.Sort(kbLogs)
-		sort.Sort(logs)
 
-		for i, p := range kbLogs {
-			if p != logs[i] {
-				t.Errorf("mismatch of log at index %d", i)
+		for _, kbid := range kbLogs {
+			found := false
+			for _, id := range logs {
+				if kbid.String() == id.String() {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("%s not found in store list", kbid.String())
 			}
 		}
 	}
@@ -233,13 +238,17 @@ func testKeyBookThreads(kb tstore.KeyBook) func(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error when getting thread from keys: %v", err)
 		}
-		sort.Sort(kbThreads)
-		sort.Sort(threads)
 
-		for i, p := range kbThreads {
-			t.Logf("%d: kb: %s, mem: %s", i, p.String(), threads[i].String())
-			if p != threads[i] {
-				t.Errorf("mismatch of thread at index %d", i)
+		for _, kbid := range kbThreads {
+			found := false
+			for _, id := range threads {
+				if kbid.String() == id.String() {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("%s not found in store list", kbid.String())
 			}
 		}
 	}

--- a/test/threads_suite.go
+++ b/test/threads_suite.go
@@ -26,11 +26,11 @@ import (
 	"github.com/textileio/go-textile-threads/util"
 )
 
-var threadsSuite = map[string]func(tserv.Threadservice, tserv.Threadservice) func(*testing.T){
-	"AddPull":     testAddPull,
-	"AddPeer":     testAddPeer,
-	"AddFollower": testAddFollower,
-	"Close":       testClose,
+var threadsSuite = []map[string]func(tserv.Threadservice, tserv.Threadservice) func(*testing.T){
+	{"AddPull": testAddPull},
+	{"AddPeer": testAddPeer},
+	{"AddFollower": testAddFollower},
+	{"Close": testClose},
 }
 
 func ThreadsTest(t *testing.T) {
@@ -43,9 +43,11 @@ func ThreadsTest(t *testing.T) {
 	ts1.Host().Peerstore().AddAddrs(ts2.Host().ID(), ts2.Host().Addrs(), peerstore.PermanentAddrTTL)
 	ts2.Host().Peerstore().AddAddrs(ts1.Host().ID(), ts1.Host().Addrs(), peerstore.PermanentAddrTTL)
 
-	for name, test := range threadsSuite {
-		// Run the test.
-		t.Run(name, test(ts1, ts2))
+	for _, test := range threadsSuite {
+		for name, test := range test {
+			// Run the test.
+			t.Run(name, test(ts1, ts2))
+		}
 	}
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -155,9 +155,9 @@ func DecodeKey(k string) (*sym.Key, error) {
 	return sym.NewKey(b)
 }
 
-// CapArgs returns args with new capacity cap.
-func CapArgs(args []string, cap int) []string {
-	capped := make([]string, 0, cap)
-	copy(capped, args)
-	return capped
+// PadArgs returns args with new length pad.
+func PadArgs(args []string, len int) []string {
+	padded := make([]string, len)
+	copy(padded, args)
+	return padded
 }

--- a/util/util.go
+++ b/util/util.go
@@ -2,9 +2,13 @@ package util
 
 import (
 	"crypto/rand"
+	"strings"
 
 	ic "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/peerstore"
+	swarm "github.com/libp2p/go-libp2p-swarm"
+	"github.com/mr-tron/base58"
 	ma "github.com/multiformats/go-multiaddr"
 	sym "github.com/textileio/go-textile-core/crypto/symmetric"
 	"github.com/textileio/go-textile-core/thread"
@@ -101,4 +105,59 @@ func GetOrCreateOwnLog(t tserv.Threadservice, id thread.ID) (info thread.LogInfo
 	}
 	err = t.Store().AddLog(id, info)
 	return info, err
+}
+
+// AddPeerFromAddress parses the given address and adds the dialable component
+// to the peerstore.
+// If a dht is provided and the address does not contain a dialable component,
+// it will be queried for peer info.
+func AddPeerFromAddress(addrStr string, pstore peerstore.Peerstore) (pid peer.ID, err error) {
+	addr, err := ma.NewMultiaddr(addrStr)
+	if err != nil {
+		return
+	}
+	p2p, err := addr.ValueForProtocol(ma.P_P2P)
+	if err != nil {
+		return
+	}
+	pid, err = peer.IDB58Decode(p2p)
+	if err != nil {
+		return
+	}
+	dialable, err := GetDialable(addr)
+	if err == nil {
+		pstore.AddAddr(pid, dialable, peerstore.PermanentAddrTTL)
+	}
+
+	return pid, nil
+}
+
+// GetDialable returns the portion of an address suitable for storage in a peerstore.
+func GetDialable(addr ma.Multiaddr) (ma.Multiaddr, error) {
+	parts := strings.Split(addr.String(), "/"+ma.ProtocolWithCode(ma.P_P2P).Name)
+	return ma.NewMultiaddr(parts[0])
+}
+
+// CanDial returns whether or not the address is dialable.
+func CanDial(addr ma.Multiaddr, s *swarm.Swarm) bool {
+	parts := strings.Split(addr.String(), "/"+ma.ProtocolWithCode(ma.P_P2P).Name)
+	addr, _ = ma.NewMultiaddr(parts[0])
+	tr := s.TransportForDialing(addr)
+	return tr != nil && tr.CanDial(addr)
+}
+
+// DecodeKey from a string into a symmetric key.
+func DecodeKey(k string) (*sym.Key, error) {
+	b, err := base58.Decode(k)
+	if err != nil {
+		return nil, err
+	}
+	return sym.NewKey(b)
+}
+
+// CapArgs returns args with new capacity cap.
+func CapArgs(args []string, cap int) []string {
+	capped := make([]string, 0, cap)
+	copy(capped, args)
+	return capped
 }

--- a/util/util.go
+++ b/util/util.go
@@ -155,9 +155,12 @@ func DecodeKey(k string) (*sym.Key, error) {
 	return sym.NewKey(b)
 }
 
-// PadArgs returns args with new length pad.
-func PadArgs(args []string, len int) []string {
-	padded := make([]string, len)
+// PadArgs returns args with min length l.
+func PadArgs(args []string, l int) []string {
+	if len(args) > l {
+		l = len(args)
+	}
+	padded := make([]string, l)
 	copy(padded, args)
 	return padded
 }

--- a/ws/hub.go
+++ b/ws/hub.go
@@ -68,6 +68,7 @@ func (h *Hub) run() {
 			jrec, err := recordToJSON(ctx, h.service, rec.Value())
 			if err != nil {
 				log.Errorf("error converting record %s to JSON: %v", rid, err)
+				cancel()
 				break
 			}
 			cancel()
@@ -106,7 +107,7 @@ type jsonThreadInfo struct {
 
 // threadInfoToJSON returns a JSON version of thread info for transport.
 func threadInfoToJSON(info thread.Info) *jsonThreadInfo {
-	var logs []string
+	logs := make([]string, 0, len(info.Logs))
 	for _, lg := range info.Logs {
 		logs = append(logs, lg.String())
 	}
@@ -161,8 +162,5 @@ func recordToJSON(ctx context.Context, dag format.DAGService, rec thread.Record)
 
 // encodeNode returns a base64-encoded version of n.
 func encodeNode(n format.Node) string {
-	data := n.RawData()
-	encoded := make([]byte, base64.StdEncoding.EncodedLen(len(data)))
-	base64.StdEncoding.Encode(encoded, data)
-	return string(encoded)
+	return base64.StdEncoding.EncodeToString(n.RawData())
 }

--- a/ws/hub.go
+++ b/ws/hub.go
@@ -3,15 +3,25 @@
 package ws
 
 import (
+	"context"
 	"encoding/base64"
+	"encoding/json"
+	"time"
 
+	format "github.com/ipfs/go-ipld-format"
+	"github.com/mr-tron/base58"
 	"github.com/textileio/go-textile-core/thread"
 	tserv "github.com/textileio/go-textile-core/threadservice"
+	"github.com/textileio/go-textile-threads/cbor"
 )
+
+var encodeRecordTimeout = time.Second * 5
 
 // Hub maintains the set of active clients and broadcasts messages to the
 // clients.
 type Hub struct {
+	ctx context.Context
+
 	// service provides thread access.
 	service tserv.Threadservice
 
@@ -29,8 +39,9 @@ type Hub struct {
 }
 
 // NewHub creates a new client hub.
-func newHub(ts tserv.Threadservice) *Hub {
+func newHub(ctx context.Context, ts tserv.Threadservice) *Hub {
 	return &Hub{
+		ctx:        ctx,
 		service:    ts,
 		broadcast:  make(chan tserv.Record),
 		register:   make(chan *Client),
@@ -51,7 +62,25 @@ func (h *Hub) run() {
 				close(client.send)
 			}
 		case rec := <-h.broadcast:
-			msg := encodeRecord(rec.Value())
+			rid := rec.Value().Cid().String()
+
+			ctx, cancel := context.WithTimeout(h.ctx, encodeRecordTimeout)
+			jrec, err := recordToJSON(ctx, h.service, rec.Value())
+			if err != nil {
+				log.Errorf("error converting record %s to JSON: %v", rid, err)
+				break
+			}
+			cancel()
+
+			jrec.LogID = rec.LogID().String()
+			jrec.ThreadID = rec.ThreadID().String()
+
+			msg, err := json.Marshal(jrec)
+			if err != nil {
+				log.Errorf("error marshaling record %s: %v", rid, err)
+				break
+			}
+
 			for client := range h.clients {
 				if _, ok := client.threads[rec.ThreadID()]; !ok {
 					continue
@@ -67,10 +96,73 @@ func (h *Hub) run() {
 	}
 }
 
-// encodeRecord base64 encodes a thread record.
-func encodeRecord(rec thread.Record) []byte {
-	data := rec.RawData()
+// jsonThreadInfo is thread info in JSON.
+type jsonThreadInfo struct {
+	ID        string   `json:"id"`
+	Logs      []string `json:"logs"`
+	FollowKey string   `json:"follow_key"`
+	ReadKey   string   `json:"read_key,omitempty"`
+}
+
+// threadInfoToJSON returns a JSON version of thread info for transport.
+func threadInfoToJSON(info thread.Info) *jsonThreadInfo {
+	var logs []string
+	for _, lg := range info.Logs {
+		logs = append(logs, lg.String())
+	}
+	return &jsonThreadInfo{
+		ID:        info.ID.String(),
+		Logs:      logs,
+		FollowKey: base58.Encode(info.FollowKey.Bytes()),
+		ReadKey:   base58.Encode(info.FollowKey.Bytes()),
+	}
+}
+
+// jsonRecord is a thread record containing link data in JSON.
+type jsonRecord struct {
+	ID       string `json:"id"`
+	LogID    string `json:"log_id,omitempty"`
+	ThreadID string `json:"thread_id"`
+
+	RecordNode string `json:"record_node,omitempty"`
+	EventNode  string `json:"event_node,omitempty"`
+	HeaderNode string `json:"header_node,omitempty"`
+	BodyNode   string `json:"body_node,omitempty"`
+}
+
+// recordToJSON returns a JSON version of a record for transport.
+// Nodes are sent encrypted.
+func recordToJSON(ctx context.Context, dag format.DAGService, rec thread.Record) (*jsonRecord, error) {
+	block, err := rec.GetBlock(ctx, dag)
+	if err != nil {
+		return nil, err
+	}
+	event, err := cbor.EventFromNode(block)
+	if err != nil {
+		return nil, err
+	}
+	header, err := event.GetHeader(ctx, dag, nil)
+	if err != nil {
+		return nil, err
+	}
+	body, err := event.GetBody(ctx, dag, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &jsonRecord{
+		ID:         rec.Cid().String(),
+		RecordNode: encodeNode(rec),
+		EventNode:  encodeNode(block),
+		HeaderNode: encodeNode(header),
+		BodyNode:   encodeNode(body),
+	}, nil
+}
+
+// encodeNode returns a base64-encoded version of n.
+func encodeNode(n format.Node) string {
+	data := n.RawData()
 	encoded := make([]byte, base64.StdEncoding.EncodedLen(len(data)))
 	base64.StdEncoding.Encode(encoded, data)
-	return encoded
+	return string(encoded)
 }

--- a/ws/server.go
+++ b/ws/server.go
@@ -19,9 +19,9 @@ type Server struct {
 }
 
 // NewServer returns a web socket server.
-func NewServer(service tserv.Threadservice, addr string) *Server {
+func NewServer(ctx context.Context, service tserv.Threadservice, addr string) *Server {
 	s := &Server{
-		hub: newHub(service),
+		hub: newHub(ctx, service),
 	}
 	go s.hub.run()
 
@@ -40,6 +40,8 @@ func NewServer(service tserv.Threadservice, addr string) *Server {
 	go func() {
 		for {
 			select {
+			case <-ctx.Done():
+				return
 			case err, ok := <-errc:
 				if err != nil && err != http.ErrServerClosed {
 					log.Errorf("ws server error: %s", err)

--- a/ws/server.go
+++ b/ws/server.go
@@ -41,13 +41,14 @@ func NewServer(ctx context.Context, service tserv.Threadservice, addr string) *S
 		for {
 			select {
 			case <-ctx.Done():
+				log.Info("context was canceled")
 				return
 			case err, ok := <-errc:
 				if err != nil && err != http.ErrServerClosed {
-					log.Errorf("ws server error: %s", err)
+					log.Errorf("server error: %s", err)
 				}
 				if !ok {
-					log.Info("ws server was shutdown")
+					log.Info("server was shutdown")
 					return
 				}
 			}
@@ -67,7 +68,7 @@ func NewServer(ctx context.Context, service tserv.Threadservice, addr string) *S
 		}
 	}()
 
-	log.Infof("ws server listening at %s", s.s.Addr)
+	log.Infof("server listening at %s", s.s.Addr)
 
 	return s
 }


### PR DESCRIPTION
Mainly this enables `getRecord` and other related methods to return a JSON encoded record:

```
// Create a new client and connect
window.client = new threads.Client()
client.connect('ws://localhost:8080').then(() => {
  const tid = 'bafkufevg3bqezf3mx7vmloyezupzkdx5ozsfudwky3o3c6kiqvqsldy'
  const rid = 'bafyreifok6utuqevl7uon255kvdg6edrcfhtnax6eueyuncpl2f3iqjewi'
  // Fetch a record
  client.getRecord(rid, tid).then((res) => {
    console.log(res)
  }).catch((err) => {
    console.error(err)
  })
})
```
Returns...
```
{
    "id": "bafyreifok6utuqevl7uon255kvdg6edrcfhtnax6eueyuncpl2f3iqjewi",
    "thread_id": "bafkufevg3bqezf3mx7vmloyezupzkdx5ozsfudwky3o3c6kiqvqsldy",
    "record_node": "WLTlVlcAFCOsk4NMRcAKLwqDjGNc3hVw/q7n3Ks0HMzi1HxQ+zBRYCPByM+wS5DDzbhUzzfLsGD8cF7vptezMshZevZOrlGSd3eGFD4QXncSe1AYO1cTMY5bHiCU3bwbA0osDdBSvwKXWIXfbb2wP9yv4Tci7MgAhQB7mR6iP2VoFNhwvASr43ubwBO9VAF0IvSZODHsGhCQnrjaLG+A2vovzVmcOpiMQ7ic+y9qmDm1Ymv6xpU=",
    "event_node": "omRib2R52CpYJQABcRIgovMszk/9Y2dDNea4JkTTZkyLgLkfw/GU8VmjF04z8AJmaGVhZGVy2CpYJQABcRIgSURimRMwYvozolv0wNcs6OrgWmlwzOSkGPsvEmLd6/A=",
    "body_node": "WCIICIELEYVXuTDIjV7gCwMRL3UqY7z/oM5n1E1+/lTWsEOg",
    "header_node": "WE2F79iDylvfauQPLNYvyip5CTeY37W//uLRT0HtOCoN+L+rJ3J7XTMxwVdowe+i/naasl8ptqw/O2jT9M212Iy4ZgAXKUu4kmarzLXVeQ=="
}
```

From that info, you can construct the full fledged record CBOR node (same as in the normal thread service, assuming you have the keys).