### PR TITLE
store: multiple issue fixes

### DIFF
--- a/eventstore/model_test.go
+++ b/eventstore/model_test.go
@@ -31,7 +31,7 @@ type Comment struct {
 }
 
 func TestMain(m *testing.M) {
-	logging.SetLogLevel("*", "debug")
+	logging.SetLogLevel("*", "error")
 	os.Exit(m.Run())
 }
 
@@ -399,7 +399,14 @@ func assertPersonInModel(t *testing.T, model *Model, person *Person) {
 func createTestStore(t *testing.T) (*Store, func()) {
 	dir, err := ioutil.TempDir("", "")
 	checkErr(t, err)
-	s, err := NewStore(WithRepoPath(dir))
+	ts, err := DefaultThreadservice(0, dir, false)
 	checkErr(t, err)
-	return s, func() { os.RemoveAll(dir) }
+	s, err := NewStore(ts, WithRepoPath(dir))
+	checkErr(t, err)
+	return s, func() {
+		if err := ts.Close(); err != nil {
+			panic(err)
+		}
+		os.RemoveAll(dir)
+	}
 }

--- a/eventstore/model_test.go
+++ b/eventstore/model_test.go
@@ -399,7 +399,7 @@ func assertPersonInModel(t *testing.T, model *Model, person *Person) {
 func createTestStore(t *testing.T) (*Store, func()) {
 	dir, err := ioutil.TempDir("", "")
 	checkErr(t, err)
-	ts, err := DefaultThreadservice(0, dir, false)
+	ts, err := DefaultThreadservice(dir, ProxyPort(0))
 	checkErr(t, err)
 	s, err := NewStore(ts, WithRepoPath(dir))
 	checkErr(t, err)

--- a/eventstore/options.go
+++ b/eventstore/options.go
@@ -1,41 +1,17 @@
 package eventstore
 
 import (
-	"context"
-	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
-	"time"
 
-	ipfslite "github.com/hsanjuan/ipfs-lite"
 	ds "github.com/ipfs/go-datastore"
 	badger "github.com/ipfs/go-ds-badger"
-	"github.com/libp2p/go-libp2p"
-	connmgr "github.com/libp2p/go-libp2p-connmgr"
-	ic "github.com/libp2p/go-libp2p-core/crypto"
-	"github.com/libp2p/go-libp2p-core/peer"
-	"github.com/libp2p/go-libp2p-peerstore/pstoreds"
-	ma "github.com/multiformats/go-multiaddr"
 	core "github.com/textileio/go-textile-core/store"
-	"github.com/textileio/go-textile-core/threadservice"
-	t "github.com/textileio/go-textile-threads"
 	"github.com/textileio/go-textile-threads/jsonpatcher"
-	"github.com/textileio/go-textile-threads/tstoreds"
 )
 
 const (
-	defaultDatastorePath = "/datastore"
-	defaultIpfsLitePath  = "/ipfslite"
-	defaultListeningPort = 5002
-)
-
-var (
-	bootstrapPeers = []string{
-		"/ip4/104.210.43.77/tcp/4001/ipfs/12D3KooWSdGmRz5JQidqrtmiPGVHkStXpbSAMnbCcW8abq6zuiDP", // us-west
-		"/ip4/20.39.232.27/tcp/4001/ipfs/12D3KooWLnUv9MWuRM6uHirRPBM4NwRj54n4gNNnBtiFiwPiv3Up",  // eu-west
-		"/ip4/34.87.103.105/tcp/4001/ipfs/12D3KooWA5z2C3z1PNKi36Bw1MxZhBD8nv7UbB7YQP6WcSWYNwRQ", // as-southeast
-	}
+	defaultDatastorePath = "datastore"
 )
 
 // StoreOption takes a StoreConfig and modifies it
@@ -43,13 +19,11 @@ type StoreOption func(*StoreConfig) error
 
 // StoreConfig has configuration parameters for a store
 type StoreConfig struct {
-	ListenPort    int
-	RepoPath      string
-	Datastore     ds.Datastore
-	Threadservice threadservice.Threadservice
-	EventCodec    core.EventCodec
-	JsonMode      bool
-	Debug         bool
+	RepoPath   string
+	Datastore  ds.Datastore
+	EventCodec core.EventCodec
+	JsonMode   bool
+	Debug      bool
 }
 
 func newDefaultEventCodec(jsonMode bool) core.EventCodec {
@@ -62,67 +36,6 @@ func newDefaultDatastore(repoPath string) (ds.Datastore, error) {
 		return nil, err
 	}
 	return badger.NewDatastore(path, &badger.DefaultOptions)
-}
-
-func newDefaultThreadservice(ctx context.Context, listenPort int, repoPath string, debug bool) (threadservice.Threadservice, error) {
-	ipfsLitePath := filepath.Join(repoPath, defaultIpfsLitePath)
-	if err := os.MkdirAll(ipfsLitePath, os.ModePerm); err != nil {
-		return nil, err
-	}
-	ds, err := ipfslite.BadgerDatastore(ipfsLitePath)
-	if err != nil {
-		return nil, err
-	}
-	go func() {
-		<-ctx.Done()
-		ds.Close()
-	}()
-
-	pstore, err := pstoreds.NewPeerstore(ctx, ds, pstoreds.DefaultOpts())
-	if err != nil {
-		return nil, err
-	}
-	listen, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", listenPort))
-	if err != nil {
-		return nil, err
-	}
-	priv := loadKey(filepath.Join(ipfsLitePath, "key"))
-	h, dht, err := ipfslite.SetupLibp2p(
-		ctx,
-		priv,
-		nil,
-		[]ma.Multiaddr{listen},
-		libp2p.ConnectionManager(connmgr.NewConnManager(100, 400, time.Minute)),
-		libp2p.Peerstore(pstore),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	lite, err := ipfslite.New(ctx, ds, h, dht, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// Build a threadstore
-	tstore, err := tstoreds.NewThreadstore(ctx, ds, tstoreds.DefaultOpts())
-	if err != nil {
-		return nil, err
-	}
-
-	// Build a threadservice
-	api, err := t.NewThreads(ctx, h, lite.BlockStore(), lite, tstore, t.Options{
-		Debug: debug,
-	})
-	if err != nil {
-		return nil, err
-	}
-	boots, err := parseBootstrapPeers(bootstrapPeers)
-	if err != nil {
-		return nil, err
-	}
-	lite.Bootstrap(boots)
-	return api, nil
 }
 
 func WithJsonMode(enabled bool) StoreOption {
@@ -147,25 +60,6 @@ func WithDebug(enable bool) StoreOption {
 	}
 }
 
-// WithThreadservice indicate to use a particular Threadservice
-// implementation for Thread syncing. This configuration takes
-// priority over WithListenPort.
-func WithThreadservice(ts threadservice.Threadservice) StoreOption {
-	return func(sc *StoreConfig) error {
-		sc.Threadservice = ts
-		return nil
-	}
-}
-
-// WithListenPort indicate the port which the automatically
-// instantiated Threadservice IPFSLite instance will listen
-func WithListenPort(port int) StoreOption {
-	return func(sc *StoreConfig) error {
-		sc.ListenPort = port
-		return nil
-	}
-}
-
 // WithEventCodec configure to use ec as the EventCodec
 // manager for transforming actions in events, and viceversa
 func WithEventCodec(ec core.EventCodec) StoreOption {
@@ -173,46 +67,4 @@ func WithEventCodec(ec core.EventCodec) StoreOption {
 		sc.EventCodec = ec
 		return nil
 	}
-}
-
-func loadKey(pth string) ic.PrivKey {
-	var priv ic.PrivKey
-	_, err := os.Stat(pth)
-	if os.IsNotExist(err) {
-		priv, _, err = ic.GenerateKeyPair(ic.Ed25519, 0)
-		if err != nil {
-			panic(err)
-		}
-		key, err := ic.MarshalPrivateKey(priv)
-		if err != nil {
-			panic(err)
-		}
-		if err = ioutil.WriteFile(pth, key, 0400); err != nil {
-			panic(err)
-		}
-	} else if err != nil {
-		panic(err)
-	} else {
-		key, err := ioutil.ReadFile(pth)
-		if err != nil {
-			panic(err)
-		}
-		priv, err = ic.UnmarshalPrivateKey(key)
-		if err != nil {
-			panic(err)
-		}
-	}
-	return priv
-}
-
-func parseBootstrapPeers(addrs []string) ([]peer.AddrInfo, error) {
-	maddrs := make([]ma.Multiaddr, len(addrs))
-	for i, addr := range addrs {
-		var err error
-		maddrs[i], err = ma.NewMultiaddr(addr)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return peer.AddrInfosFromP2pAddrs(maddrs...)
 }

--- a/eventstore/store_test.go
+++ b/eventstore/store_test.go
@@ -1,7 +1,6 @@
 package eventstore
 
 import (
-	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -10,6 +9,7 @@ import (
 	ds "github.com/ipfs/go-datastore"
 	"github.com/multiformats/go-multiaddr"
 	core "github.com/textileio/go-textile-core/store"
+	"github.com/textileio/go-textile-threads/util"
 )
 
 func TestE2EWithThreads(t *testing.T) {
@@ -19,7 +19,12 @@ func TestE2EWithThreads(t *testing.T) {
 	tmpDir1, err := ioutil.TempDir("", "")
 	checkErr(t, err)
 	defer os.RemoveAll(tmpDir1)
-	s1, err := NewStore(WithRepoPath(tmpDir1), WithListenPort(8005))
+	ts1, err := DefaultThreadservice(0, tmpDir1, false)
+	checkErr(t, err)
+	ts1.Bootstrap(util.DefaultBoostrapPeers())
+	defer ts1.Close()
+
+	s1, err := NewStore(ts1, WithRepoPath(tmpDir1))
 	checkErr(t, err)
 	defer s1.Close()
 	m1, err := s1.Register("dummy", &dummyModel{})
@@ -48,7 +53,12 @@ func TestE2EWithThreads(t *testing.T) {
 	tmpDir2, err := ioutil.TempDir("", "")
 	checkErr(t, err)
 	defer os.RemoveAll(tmpDir2)
-	s2, err := NewStore(WithRepoPath(tmpDir2), WithListenPort(8006))
+	ts2, err := DefaultThreadservice(0, tmpDir2, false)
+	checkErr(t, err)
+	ts2.Bootstrap(util.DefaultBoostrapPeers())
+	defer ts2.Close()
+
+	s2, err := NewStore(ts2, WithRepoPath(tmpDir2))
 	checkErr(t, err)
 	defer s2.Close()
 	m2, err := s2.Register("dummy", &dummyModel{})
@@ -70,11 +80,11 @@ func TestOptions(t *testing.T) {
 	checkErr(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	ts, err := newDefaultThreadservice(ctx, 8008, tmpDir, true)
+	ts, err := DefaultThreadservice(0, tmpDir, false)
 	checkErr(t, err)
+
 	ec := &mockEventCodec{}
-	s, err := NewStore(WithDebug(true), WithEventCodec(ec), WithListenPort(8008), WithRepoPath(tmpDir), WithThreadservice(ts))
+	s, err := NewStore(ts, WithRepoPath(tmpDir), WithEventCodec(ec))
 	checkErr(t, err)
 
 	m, err := s.Register("dummy", &dummyModel{})
@@ -86,14 +96,16 @@ func TestOptions(t *testing.T) {
 	}
 
 	// Re-do again to re-use key. If something wasn't closed correctly, would fail
+	ts.Close()
 	s.Close()
-	cancel()
 
-	time.Sleep(time.Second * 1)
-	ts, err = newDefaultThreadservice(context.Background(), 8008, tmpDir, true)
+	time.Sleep(time.Second * 3)
+	ts, err = DefaultThreadservice(0, tmpDir, false)
 	checkErr(t, err)
-	_, err = NewStore(WithDebug(true), WithEventCodec(ec), WithListenPort(8008), WithRepoPath(tmpDir), WithThreadservice(ts))
+	defer ts.Close()
+	s, err = NewStore(ts, WithRepoPath(tmpDir), WithEventCodec(ec))
 	checkErr(t, err)
+	defer s.Close()
 }
 
 type dummyModel struct {

--- a/eventstore/store_test.go
+++ b/eventstore/store_test.go
@@ -19,7 +19,7 @@ func TestE2EWithThreads(t *testing.T) {
 	tmpDir1, err := ioutil.TempDir("", "")
 	checkErr(t, err)
 	defer os.RemoveAll(tmpDir1)
-	ts1, err := DefaultThreadservice(0, tmpDir1, false)
+	ts1, err := DefaultThreadservice(tmpDir1, ProxyPort(0))
 	checkErr(t, err)
 	ts1.Bootstrap(util.DefaultBoostrapPeers())
 	defer ts1.Close()
@@ -53,7 +53,7 @@ func TestE2EWithThreads(t *testing.T) {
 	tmpDir2, err := ioutil.TempDir("", "")
 	checkErr(t, err)
 	defer os.RemoveAll(tmpDir2)
-	ts2, err := DefaultThreadservice(0, tmpDir2, false)
+	ts2, err := DefaultThreadservice(tmpDir2, ProxyPort(0))
 	checkErr(t, err)
 	ts2.Bootstrap(util.DefaultBoostrapPeers())
 	defer ts2.Close()
@@ -80,7 +80,7 @@ func TestOptions(t *testing.T) {
 	checkErr(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	ts, err := DefaultThreadservice(0, tmpDir, false)
+	ts, err := DefaultThreadservice(tmpDir, ProxyPort(0))
 	checkErr(t, err)
 
 	ec := &mockEventCodec{}
@@ -100,7 +100,7 @@ func TestOptions(t *testing.T) {
 	s.Close()
 
 	time.Sleep(time.Second * 3)
-	ts, err = DefaultThreadservice(0, tmpDir, false)
+	ts, err = DefaultThreadservice(tmpDir, ProxyPort(0))
 	checkErr(t, err)
 	defer ts.Close()
 	s, err = NewStore(ts, WithRepoPath(tmpDir), WithEventCodec(ec))

--- a/eventstore/util.go
+++ b/eventstore/util.go
@@ -103,7 +103,7 @@ func DefaultThreadservice(repoPath string, opts ...Option) (ThreadserviceBoostra
 		return nil, err
 	}
 
-	return &tservBoostraper{
+	return &tservBoostrapper{
 		cancel:        cancel,
 		Threadservice: api,
 		litepeer:      lite,
@@ -140,20 +140,20 @@ func Debug(enabled bool) Option {
 	}
 }
 
-type tservBoostraper struct {
+type tservBoostrapper struct {
 	cancel context.CancelFunc
 	tserv.Threadservice
 	litepeer *ipfslite.Peer
 	ds       datastore.Datastore
 }
 
-var _ ThreadserviceBoostrapper = (*tservBoostraper)(nil)
+var _ ThreadserviceBoostrapper = (*tservBoostrapper)(nil)
 
-func (tsb *tservBoostraper) Bootstrap(addrs []peer.AddrInfo) {
+func (tsb *tservBoostrapper) Bootstrap(addrs []peer.AddrInfo) {
 	tsb.litepeer.Bootstrap(addrs)
 }
 
-func (tsb *tservBoostraper) Close() error {
+func (tsb *tservBoostrapper) Close() error {
 	tsb.cancel()
 	if err := tsb.ds.Close(); err != nil {
 		return err

--- a/eventstore/util.go
+++ b/eventstore/util.go
@@ -1,0 +1,125 @@
+package eventstore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	ipfslite "github.com/hsanjuan/ipfs-lite"
+	"github.com/ipfs/go-datastore"
+	"github.com/libp2p/go-libp2p"
+	connmgr "github.com/libp2p/go-libp2p-connmgr"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-peerstore/pstoreds"
+	ma "github.com/multiformats/go-multiaddr"
+	tserv "github.com/textileio/go-textile-core/threadservice"
+	t "github.com/textileio/go-textile-threads"
+	"github.com/textileio/go-textile-threads/tstoreds"
+	util "github.com/textileio/go-textile-threads/util"
+)
+
+const (
+	defaultIpfsLitePath  = "ipfslite"
+	defaultListeningPort = 5002
+)
+
+// DefaultThreadService is a boostrapable default Threadservice with
+// sane defaults.
+type ThreadserviceBoostrapper interface {
+	tserv.Threadservice
+	Bootstrap(addrs []peer.AddrInfo)
+}
+
+func DefaultThreadservice(listenPort int, repoPath string, debug bool) (ThreadserviceBoostrapper, error) {
+	ipfsLitePath := filepath.Join(repoPath, defaultIpfsLitePath)
+	if err := os.MkdirAll(ipfsLitePath, os.ModePerm); err != nil {
+		return nil, err
+	}
+	ds, err := ipfslite.BadgerDatastore(ipfsLitePath)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	pstore, err := pstoreds.NewPeerstore(ctx, ds, pstoreds.DefaultOpts())
+	if err != nil {
+		ds.Close()
+		cancel()
+		return nil, err
+	}
+	listen, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", listenPort))
+	if err != nil {
+		ds.Close()
+		cancel()
+		return nil, err
+	}
+	priv := util.LoadKey(filepath.Join(ipfsLitePath, "key"))
+	h, dht, err := ipfslite.SetupLibp2p(
+		ctx,
+		priv,
+		nil,
+		[]ma.Multiaddr{listen},
+		libp2p.ConnectionManager(connmgr.NewConnManager(100, 400, time.Minute)),
+		libp2p.Peerstore(pstore),
+	)
+	if err != nil {
+		ds.Close()
+		cancel()
+		return nil, err
+	}
+
+	lite, err := ipfslite.New(ctx, ds, h, dht, nil)
+	if err != nil {
+		ds.Close()
+		cancel()
+		return nil, err
+	}
+
+	// Build a threadstore
+	tstore, err := tstoreds.NewThreadstore(ctx, ds, tstoreds.DefaultOpts())
+	if err != nil {
+		ds.Close()
+		cancel()
+		return nil, err
+	}
+
+	// Build a threadservice
+	api, err := t.NewThreads(ctx, h, lite.BlockStore(), lite, tstore, t.Options{
+		Debug: debug,
+	})
+	if err != nil {
+		ds.Close()
+		cancel()
+		return nil, err
+	}
+
+	return &tservBoostraper{
+		cancel:        cancel,
+		Threadservice: api,
+		litepeer:      lite,
+		ds:            ds,
+	}, nil
+}
+
+type tservBoostraper struct {
+	cancel context.CancelFunc
+	tserv.Threadservice
+	litepeer *ipfslite.Peer
+	ds       datastore.Datastore
+}
+
+var _ ThreadserviceBoostrapper = (*tservBoostraper)(nil)
+
+func (tsb *tservBoostraper) Bootstrap(addrs []peer.AddrInfo) {
+	tsb.litepeer.Bootstrap(addrs)
+}
+
+func (tsb *tservBoostraper) Close() error {
+	tsb.cancel()
+	if err := tsb.ds.Close(); err != nil {
+		return err
+	}
+	return tsb.Threadservice.Close()
+}

--- a/exe/e2e_counter/reader.go
+++ b/exe/e2e_counter/reader.go
@@ -15,7 +15,7 @@ func runReaderPeer(repo string, port int) {
 	fmt.Printf("I'm a model reader.\n")
 	writerAddr, fkey, rkey := getWriterAddr()
 
-	ts, err := es.DefaultThreadservice(0, repo, false)
+	ts, err := es.DefaultThreadservice(repo, es.ProxyPort(0))
 	checkErr(err)
 	defer ts.Close()
 	store, err := es.NewStore(ts, es.WithRepoPath(repo))

--- a/exe/e2e_counter/reader.go
+++ b/exe/e2e_counter/reader.go
@@ -15,7 +15,10 @@ func runReaderPeer(repo string, port int) {
 	fmt.Printf("I'm a model reader.\n")
 	writerAddr, fkey, rkey := getWriterAddr()
 
-	store, err := es.NewStore(es.WithRepoPath(repo), es.WithDebug(true))
+	ts, err := es.DefaultThreadservice(0, repo, false)
+	checkErr(err)
+	defer ts.Close()
+	store, err := es.NewStore(ts, es.WithRepoPath(repo))
 	checkErr(err)
 	defer store.Close()
 

--- a/exe/e2e_counter/writer.go
+++ b/exe/e2e_counter/writer.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/mr-tron/base58"
 	"github.com/multiformats/go-multiaddr"
-	"github.com/textileio/go-textile-core/thread"
 	core "github.com/textileio/go-textile-core/store"
+	"github.com/textileio/go-textile-core/thread"
 	es "github.com/textileio/go-textile-threads/eventstore"
 )
 
@@ -21,7 +21,10 @@ type myCounter struct {
 func runWriterPeer(repo string, port int) {
 	fmt.Printf("I'm a writer\n")
 
-	store, err := es.NewStore(es.WithRepoPath(repo), es.WithDebug(true))
+	ts, err := es.DefaultThreadservice(0, repo, false)
+	checkErr(err)
+	defer ts.Close()
+	store, err := es.NewStore(ts, es.WithRepoPath(repo))
 	checkErr(err)
 	defer store.Close()
 

--- a/exe/e2e_counter/writer.go
+++ b/exe/e2e_counter/writer.go
@@ -21,7 +21,7 @@ type myCounter struct {
 func runWriterPeer(repo string, port int) {
 	fmt.Printf("I'm a writer\n")
 
-	ts, err := es.DefaultThreadservice(0, repo, false)
+	ts, err := es.DefaultThreadservice(repo, es.ProxyPort(0))
 	checkErr(err)
 	defer ts.Close()
 	store, err := es.NewStore(ts, es.WithRepoPath(repo))

--- a/exe/local_eventstore/books/main.go
+++ b/exe/local_eventstore/books/main.go
@@ -152,7 +152,7 @@ func main() {
 func createMemStore() (*es.Store, func()) {
 	dir, err := ioutil.TempDir("", "")
 	checkErr(err)
-	ts, err := es.DefaultThreadservice(0, dir, false)
+	ts, err := es.DefaultThreadservice(dir, es.ProxyPort(0))
 	checkErr(err)
 	s, err := es.NewStore(ts, es.WithRepoPath(dir))
 	checkErr(err)

--- a/exe/local_eventstore/books/main.go
+++ b/exe/local_eventstore/books/main.go
@@ -152,9 +152,16 @@ func main() {
 func createMemStore() (*es.Store, func()) {
 	dir, err := ioutil.TempDir("", "")
 	checkErr(err)
-	s, err := es.NewStore(es.WithRepoPath(dir))
+	ts, err := es.DefaultThreadservice(0, dir, false)
 	checkErr(err)
-	return s, func() { os.RemoveAll(dir) }
+	s, err := es.NewStore(ts, es.WithRepoPath(dir))
+	checkErr(err)
+	return s, func() {
+		if err := ts.Close(); err != nil {
+			panic(err)
+		}
+		os.RemoveAll(dir)
+	}
 }
 
 func checkErr(err error) {

--- a/exe/local_eventstore/json-books/main.go
+++ b/exe/local_eventstore/json-books/main.go
@@ -105,7 +105,7 @@ func main() {
 
 		exists, err = model.Has(entityID)
 		checkErr(err)
-		if !exists {
+		if exists {
 			panic("instance shouldn't exist")
 		}
 	}
@@ -114,9 +114,16 @@ func main() {
 func createJsonModeMemStore() (*es.Store, func()) {
 	dir, err := ioutil.TempDir("", "")
 	checkErr(err)
-	s, err := es.NewStore(es.WithRepoPath(dir), es.WithJsonMode(true))
+	ts, err := es.DefaultThreadservice(0, dir, false)
 	checkErr(err)
-	return s, func() { os.RemoveAll(dir) }
+	s, err := es.NewStore(ts, es.WithRepoPath(dir), es.WithJsonMode(true))
+	checkErr(err)
+	return s, func() {
+		if err := ts.Close(); err != nil {
+			panic(err)
+		}
+		os.RemoveAll(dir)
+	}
 }
 
 func checkErr(err error) {

--- a/exe/local_eventstore/json-books/main.go
+++ b/exe/local_eventstore/json-books/main.go
@@ -114,7 +114,7 @@ func main() {
 func createJsonModeMemStore() (*es.Store, func()) {
 	dir, err := ioutil.TempDir("", "")
 	checkErr(err)
-	ts, err := es.DefaultThreadservice(0, dir, false)
+	ts, err := es.DefaultThreadservice(dir, es.ProxyPort(0))
 	checkErr(err)
 	s, err := es.NewStore(ts, es.WithRepoPath(dir), es.WithJsonMode(true))
 	checkErr(err)

--- a/exe/util/util.go
+++ b/exe/util/util.go
@@ -3,7 +3,6 @@ package util
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -13,9 +12,7 @@ import (
 	logging "github.com/ipfs/go-log"
 	"github.com/libp2p/go-libp2p"
 	connmgr "github.com/libp2p/go-libp2p-connmgr"
-	ic "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/host"
-	"github.com/libp2p/go-libp2p-core/peer"
 	kaddht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p-peerstore/pstoreds"
 	"github.com/mitchellh/go-homedir"
@@ -53,7 +50,7 @@ func Build(repo string, port int, proxyAddr string, debug bool) (
 	ctx, cancel = context.WithCancel(context.Background())
 
 	// Build an IPFS-Lite peer
-	priv := LoadKey(filepath.Join(repop, "key"))
+	priv := util.LoadKey(filepath.Join(repop, "key"))
 
 	ds, err = ipfslite.BadgerDatastore(repop)
 	if err != nil {
@@ -106,55 +103,11 @@ func Build(repo string, port int, proxyAddr string, debug bool) (
 	if err = logging.SetLogLevel("ipfslite", "debug"); err != nil {
 		panic(err)
 	}
-	boots, err := ParseBootstrapPeers(bootstrapPeers)
+	boots, err := util.ParseBootstrapPeers(bootstrapPeers)
 	if err != nil {
 		panic(err)
 	}
 	lite.Bootstrap(boots)
 
 	return
-}
-
-// LoadKey at path.
-func LoadKey(pth string) ic.PrivKey {
-	var priv ic.PrivKey
-	_, err := os.Stat(pth)
-	if os.IsNotExist(err) {
-		priv, _, err = ic.GenerateKeyPair(ic.Ed25519, 0)
-		if err != nil {
-			panic(err)
-		}
-		key, err := ic.MarshalPrivateKey(priv)
-		if err != nil {
-			panic(err)
-		}
-		if err = ioutil.WriteFile(pth, key, 0400); err != nil {
-			panic(err)
-		}
-	} else if err != nil {
-		panic(err)
-	} else {
-		key, err := ioutil.ReadFile(pth)
-		if err != nil {
-			panic(err)
-		}
-		priv, err = ic.UnmarshalPrivateKey(key)
-		if err != nil {
-			panic(err)
-		}
-	}
-	return priv
-}
-
-// ParseBootstrapPeers returns address info from a list of string addresses.
-func ParseBootstrapPeers(addrs []string) ([]peer.AddrInfo, error) {
-	maddrs := make([]ma.Multiaddr, len(addrs))
-	for i, addr := range addrs {
-		var err error
-		maddrs[i], err = ma.NewMultiaddr(addr)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return peer.AddrInfosFromP2pAddrs(maddrs...)
 }


### PR DESCRIPTION
The `DefaultThreadService` lives in the `eventstore` package.
Originally, I moved it to `util` but we have a circular dependency (utils, threads, threadstore, utils). Trying on `threads`, gets the same circular dependency (threads, threadstore, threads).

Some general points:
- reduced log levels to errors in tests
- Fixes #86 
- Fixes #87 
- Fixes #90
- Fixes #107
- makes tests pass

Besides implementation details, may worth taking a look again to `TestE2EWithThreads` to see how it impacted end user experience, in short:
1. Create `DefaultThreadService()` with an explicit `repoPath`, and optionals: `ListenPort` for listening IPFS Lite, `ProxyPort` if want to avoid default `5050`, and `Debug` for enabling debug lefel.
2. Create the `Store` using that `Threadservice`.
3. Eventually, client *is responsible* for closing both `Threadservice` (the created default), and `Store`.
4. The client is also responsible for calling `Boostrap(..)` on the default `Threadservice`. Note that `Boostrap()` isn't part of `Threadservice` interface, but an [augmented one](https://github.com/textileio/go-textile-threads/blob/d253be406e70687077fec794d86221ab52bb7425/eventstore/util.go#L30) (only default instances have this method).
