### PR TITLE
threads: force connect when adding thread

### DIFF
--- a/eventstore/store_test.go
+++ b/eventstore/store_test.go
@@ -9,7 +9,6 @@ import (
 	ds "github.com/ipfs/go-datastore"
 	"github.com/multiformats/go-multiaddr"
 	core "github.com/textileio/go-textile-core/store"
-	"github.com/textileio/go-textile-threads/util"
 )
 
 func TestE2EWithThreads(t *testing.T) {
@@ -21,7 +20,6 @@ func TestE2EWithThreads(t *testing.T) {
 	defer os.RemoveAll(tmpDir1)
 	ts1, err := DefaultThreadservice(tmpDir1, ProxyPort(0))
 	checkErr(t, err)
-	ts1.Bootstrap(util.DefaultBoostrapPeers())
 	defer ts1.Close()
 
 	s1, err := NewStore(ts1, WithRepoPath(tmpDir1))
@@ -55,7 +53,6 @@ func TestE2EWithThreads(t *testing.T) {
 	defer os.RemoveAll(tmpDir2)
 	ts2, err := DefaultThreadservice(tmpDir2, ProxyPort(0))
 	checkErr(t, err)
-	ts2.Bootstrap(util.DefaultBoostrapPeers())
 	defer ts2.Close()
 
 	s2, err := NewStore(ts2, WithRepoPath(tmpDir2))

--- a/threads.go
+++ b/threads.go
@@ -234,6 +234,18 @@ func (t *threads) AddThread(
 		return
 	}
 
+	threadMultiaddr, err := ma.NewComponent("thread", idstr)
+	if err != nil {
+		return
+	}
+	peerAddr := addr.Decapsulate(threadMultiaddr)
+	addri, err := peer.AddrInfoFromP2pAddr(peerAddr)
+	if err != nil {
+		return
+	}
+	if err = t.Host().Connect(ctx, *addri); err != nil {
+		return
+	}
 	lgs, err := t.service.getLogs(ctx, id, pid)
 	if err != nil {
 		return


### PR DESCRIPTION
@sanderpick , here's a PR to show a bug that I'd like your confirmation.
The current PR has the fix, but let me explain the situation.

If you run `TestE2EWithThreads` test (with boostrap commented as shown) without the patch here showed in `threads.go`, the test fail with:
`store_test.go:65: rpc error: code = Unavailable desc = all SubConns are in TransientFailure, latest connection error: connection error: desc = "transport: Error while dialing failed to find any peer in table"`
If you re-enable boostrap in the test, the test pass OK.

From a conceptual POV, this didn't made sense. Why I would need to boostrap with cafes (since are the defaults now) to let two peers sync to each other, where one of them joined with a thread link?

Was quite hard to figure out since the error was too generic and didn't give a clue on where was the problem.

The problem was in ` 	lgs, err := t.service.getLogs(ctx, id, pid)`, just below the patch I did in `threads.go`. The problem there was that the gRPC connection failed since it doesn't know how to resolve the peer.ID addrs.

What I added was to explicitly connect to the peer corresponding to the Thread link, so to avoid that problem. This solves the problem... now unboostrapped peers sync correctly.

I wanted to know your opinion... this seems reasonable to me, since why not connect to the peer of the thread link?. But I'm not sure that is the right place, or something else should have done this job correctly. The good part is that is easy to reproduce: take this PR, and comment only the changes in `thread.go`, then `go run ./eventstore -run TestE2EWithThreads`.


