### PR TITLE
Imperative Transactions

### DIFF
--- a/eventstore/model.go
+++ b/eventstore/model.go
@@ -66,11 +66,31 @@ func newModelFromSchema(name string, schema string, s *Store) *Model {
 	return m
 }
 
+// StartReadTxn starts a read transation and returns it
+func (m *Model) StartReadTxn() *Txn {
+	return m.store.startReadTxn(m)
+}
+
+// EndReadTxn ends the specified read transaction
+func (m *Model) EndReadTxn(txn *Txn) {
+	m.store.endReadTxn(txn)
+}
+
 // ReadTxn creates an explicit readonly transaction. Any operation
 // that tries to mutate an instance of the model will ErrReadonlyTx.
 // Provides serializable isolation gurantees.
 func (m *Model) ReadTxn(f func(txn *Txn) error) error {
 	return m.store.readTxn(m, f)
+}
+
+// StartWriteTxn starts a write transation and returns it
+func (m *Model) StartWriteTxn() *Txn {
+	return m.store.startWriteTxn(m)
+}
+
+// EndWriteTxn ends the specified write transaction, optionally commiting its changes
+func (m *Model) EndWriteTxn(txn *Txn, commit bool) error {
+	return m.store.endWriteTxn(txn, commit)
 }
 
 // WriteTxn creates an explicit write transaction. Provides


### PR DESCRIPTION
Adds api for imperatively creating, using, and committing transactions.

I started playing with how we might implement transactions over the gRPC api, and I'm feeling pretty confident that something like this will be necessary. Thinking is that the gRPC service will need to maintain a map of active transactions (zero or one per `Store`) and if a transaction exists for a `Store`, run all subsequent requests for that `Store` against its transaction. Once `EndTransaction` is called for a `Store`, that `Store`'s transaction is removed from the map and subsequent calls return to normal (using implicit transactions).

For sure a reach with my current grasp on Go, but hopefully this gets the idea across.