### PR TITLE
threads: temporary concurrency disabling

### DIFF
--- a/client.go
+++ b/client.go
@@ -189,7 +189,8 @@ func (s *service) getRecords(
 	wg := sync.WaitGroup{}
 	for _, addr := range lg.Addrs {
 		wg.Add(1)
-		go func(addr ma.Multiaddr) {
+		// ToDo: fix concurrency
+		func(addr ma.Multiaddr) {
 			defer wg.Done()
 			p, err := addr.ValueForProtocol(ma.P_P2P)
 			if err != nil {

--- a/service.go
+++ b/service.go
@@ -87,6 +87,9 @@ func (s *service) GetLogs(ctx context.Context, req *pb.GetLogsRequest) (*pb.GetL
 // @todo: Verification
 // @todo: Don't overwrite info from non-owners
 func (s *service) PushLog(ctx context.Context, req *pb.PushLogRequest) (*pb.PushLogReply, error) {
+	// ToDo: fix concurrency
+	s.threads.pullLock.Lock()
+	defer s.threads.pullLock.Unlock()
 	if req.Header == nil {
 		return nil, status.Error(codes.FailedPrecondition, "request header is required")
 	}
@@ -147,6 +150,9 @@ func (s *service) PushLog(ctx context.Context, req *pb.PushLogRequest) (*pb.Push
 // GetRecords receives a get records request.
 // @todo: Verification
 func (s *service) GetRecords(ctx context.Context, req *pb.GetRecordsRequest) (*pb.GetRecordsReply, error) {
+	// ToDo: fix concurrency
+	s.threads.pullLock.Lock()
+	defer s.threads.pullLock.Unlock()
 	if req.Header == nil {
 		return nil, status.Error(codes.FailedPrecondition, "request header is required")
 	}

--- a/threads.go
+++ b/threads.go
@@ -273,12 +273,14 @@ func (t *threads) PullThread(ctx context.Context, id thread.ID) error {
 	log.Debugf("pulling thread %s...", id.String())
 	var ptl chan struct{}
 	var ok bool
+	// ToDo: fix concurrency
 	t.pullLock.Lock()
+	defer t.pullLock.Unlock()
 	if ptl, ok = t.pullLocks[id]; !ok {
 		ptl = make(chan struct{}, 1)
 		t.pullLocks[id] = ptl
 	}
-	t.pullLock.Unlock()
+	// t.pullLock.Unlock()
 
 	select {
 	case ptl <- struct{}{}:
@@ -304,7 +306,8 @@ func (t *threads) PullThread(ctx context.Context, id thread.ID) error {
 		wg := sync.WaitGroup{}
 		for _, lg := range lgs {
 			wg.Add(1)
-			go func(lg thread.LogInfo) {
+			// ToDo: fix concurrency
+			func(lg thread.LogInfo) {
 				defer wg.Done()
 				// Pull from addresses
 				recs, err := t.service.getRecords(
@@ -383,7 +386,8 @@ func (t *threads) AddFollower(ctx context.Context, id thread.ID, pid peer.ID) er
 	wg := sync.WaitGroup{}
 	for _, addr := range addrs {
 		wg.Add(1)
-		go func(addr ma.Multiaddr) {
+		// ToDo: fix concurrency
+		func(addr ma.Multiaddr) {
 			defer wg.Done()
 			p, err := addr.ValueForProtocol(ma.P_P2P)
 			if err != nil {
@@ -716,7 +720,8 @@ func (t *threads) startPulling() {
 			return
 		}
 		for _, id := range ts {
-			go func(id thread.ID) {
+			// ToDo: fix concurrency
+			func(id thread.ID) {
 				if err := t.PullThread(t.ctx, id); err != nil {
 					log.Errorf("error pulling thread %s: %s", id.String(), err)
 				}


### PR DESCRIPTION
This PR disables most concurrency at the peer level. It attempts to achieve safety regarding data consistency. 

All the editions have the same comments so to come back again to fix the edited points, which most probably will be soon.

In short, many `go` statements were removed. And at the `service.go` layer, it leverages `threadservice` `pullLock` lock to serialize all thread*s* interactions (quite extreme since is global lock per threadservice (which already existed for other thing, but is just temporal).

After merging, I'll create a new repo with the underlying app that uncovered some of these things... so to keep it as a reference to be sure we solved this problem correctly.
