### PR TITLE
store: jsonmode query support

### DIFF
--- a/eventstore/model.go
+++ b/eventstore/model.go
@@ -126,6 +126,15 @@ func (m *Model) Find(result interface{}, q *Query) error {
 	})
 }
 
+// FindJSON executes a Query in in JSONMode and returns the result.
+func (m *Model) FindJSON(q JSONQuery) (ret []string, err error) {
+	m.ReadTxn(func(txn *Txn) error {
+		ret, err = txn.FindJSON(q)
+		return err
+	})
+	return
+}
+
 // Reduce processes an event into the model.
 func (m *Model) Reduce(event core.Event) error {
 	log.Debugf("reducer %s start", m.name)

--- a/eventstore/model_test.go
+++ b/eventstore/model_test.go
@@ -396,12 +396,13 @@ func assertPersonInModel(t *testing.T, model *Model, person *Person) {
 	}
 }
 
-func createTestStore(t *testing.T) (*Store, func()) {
+func createTestStore(t *testing.T, opts ...StoreOption) (*Store, func()) {
 	dir, err := ioutil.TempDir("", "")
 	checkErr(t, err)
 	ts, err := DefaultThreadservice(dir, ProxyPort(0))
 	checkErr(t, err)
-	s, err := NewStore(ts, WithRepoPath(dir))
+	opts = append(opts, WithRepoPath(dir))
+	s, err := NewStore(ts, opts...)
 	checkErr(t, err)
 	return s, func() {
 		if err := ts.Close(); err != nil {

--- a/eventstore/query_json.go
+++ b/eventstore/query_json.go
@@ -1,0 +1,232 @@
+package eventstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	dsquery "github.com/ipfs/go-datastore/query"
+)
+
+type JSONQuery struct {
+	Ands []JSONCriterion
+	Ors  []JSONQuery
+	Sort JSONSort
+}
+type JSONCriterion struct {
+	FieldPath string
+	Operation JSONOperation
+	Value     JSONValue
+}
+
+type JSONValue struct {
+	String *string
+	Bool   *bool
+	Float  *float64
+}
+
+type JSONSort struct {
+	FieldPath string
+	Desc      bool
+}
+
+type JSONOperation int
+
+const (
+	Eq = JSONOperation(eq)
+	Ne = JSONOperation(ne)
+	Gt = JSONOperation(gt)
+	Lt = JSONOperation(lt)
+	Ge = JSONOperation(ge)
+	Le = JSONOperation(le)
+)
+
+type marshaledValue struct {
+	value   map[string]interface{}
+	rawJson []byte
+}
+
+func (t *Txn) FindJSON(q JSONQuery) ([]string, error) {
+	dsq := dsquery.Query{
+		Prefix: t.model.dsKey.String(),
+	}
+	dsr, err := t.model.store.datastore.Query(dsq)
+	if err != nil {
+		return nil, fmt.Errorf("error when internal query: %v", err)
+	}
+
+	var values []marshaledValue
+	for {
+		res, ok := dsr.NextSync()
+		if !ok {
+			break
+		}
+		val := make(map[string]interface{})
+		if err := json.Unmarshal(res.Value, &val); err != nil {
+			return nil, fmt.Errorf("error when unmarshaling query result: %v", err)
+		}
+		ok, err = q.matchJSON(val)
+		if err != nil {
+			return nil, fmt.Errorf("error when matching entry with query: %v", err)
+		}
+		if ok {
+			values = append(values, marshaledValue{value: val, rawJson: res.Value})
+		}
+	}
+
+	if q.Sort.FieldPath != "" {
+		var wrongField, cantCompare bool
+		sort.Slice(values, func(i, j int) bool {
+			fieldI, err := traverseFieldPathMap(values[i].value, q.Sort.FieldPath)
+			if err != nil {
+				wrongField = true
+				return false
+			}
+			fieldJ, err := traverseFieldPathMap(values[j].value, q.Sort.FieldPath)
+			if err != nil {
+				wrongField = true
+				return false
+			}
+			res, err := compare(fieldI.Interface(), fieldJ.Interface())
+			if err != nil {
+				cantCompare = true
+				return false
+			}
+			if q.Sort.Desc {
+				res *= -1
+			}
+			return res < 0
+		})
+		if wrongField {
+			return nil, ErrInvalidSortingField
+		}
+		if cantCompare {
+			panic("can't compare while sorting")
+		}
+	}
+
+	res := make([]string, len(values))
+	for i := range values {
+		res[i] = string(values[i].rawJson)
+	}
+
+	return res, nil
+}
+
+func (q *JSONQuery) matchJSON(v map[string]interface{}) (bool, error) {
+	if q == nil {
+		panic("query can't be nil")
+	}
+
+	andOk := true
+	for _, c := range q.Ands {
+		fieldRes, err := traverseFieldPathMap(v, c.FieldPath)
+		if err != nil {
+			return false, err
+		}
+		ok, err := c.match(fieldRes)
+		if err != nil {
+			return false, err
+		}
+		andOk = andOk && ok
+		if !andOk {
+			break
+		}
+	}
+	if andOk {
+		return true, nil
+	}
+
+	for _, q := range q.Ors {
+		ok, err := q.matchJSON(v)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func compareJsonValue(value interface{}, critVal JSONValue) (int, error) {
+	if critVal.String != nil {
+		s, ok := value.(string)
+		if !ok {
+			return 0, &errTypeMismatch{value, critVal}
+		}
+		return strings.Compare(s, *critVal.String), nil
+	}
+	if critVal.Bool != nil {
+		b, ok := value.(bool)
+		if !ok {
+			return 0, &errTypeMismatch{value, critVal}
+		}
+		if *critVal.Bool == b {
+			return 0, nil
+		}
+		return -1, nil
+	}
+	if critVal.Float != nil {
+		f, ok := value.(float64)
+		if !ok {
+			return 0, &errTypeMismatch{value, critVal}
+		}
+		if f == *critVal.Float {
+			return 0, nil
+		}
+		if f < *critVal.Float {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	log.Fatalf("no underlying value for json criterion was provided")
+	return 0, nil
+}
+
+func (c *JSONCriterion) match(value reflect.Value) (bool, error) {
+	valueInterface := value.Interface()
+	result, err := compareJsonValue(valueInterface, c.Value)
+	if err != nil {
+		return false, err
+	}
+	switch c.Operation {
+	case Eq:
+		return result == 0, nil
+	case Ne:
+		return result != 0, nil
+	case Gt:
+		return result > 0, nil
+	case Lt:
+		return result < 0, nil
+	case Le:
+		return result < 0 || result == 0, nil
+	case Ge:
+		return result > 0 || result == 0, nil
+	default:
+		panic("invalid operation")
+	}
+
+}
+
+func traverseFieldPathMap(value map[string]interface{}, fieldPath string) (reflect.Value, error) {
+	fields := strings.Split(fieldPath, ".")
+
+	var curr interface{}
+	curr = value
+	for i := range fields {
+		m, ok := curr.(map[string]interface{})
+		if !ok {
+			return reflect.Value{}, fmt.Errorf("instance field %s doesn't exist in type %s", fieldPath, value)
+		}
+		v, ok := m[fields[i]]
+		if !ok {
+			return reflect.Value{}, fmt.Errorf("instance field %s doesn't exist in type %s", fieldPath, value)
+		}
+		curr = v
+	}
+	return reflect.ValueOf(curr), nil
+}

--- a/eventstore/query_jsonmode_test.go
+++ b/eventstore/query_jsonmode_test.go
@@ -1,0 +1,631 @@
+package eventstore
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+const (
+	testQueryJsonModeSchema = `{
+		"$schema": "http://json-schema.org/draft-04/schema#",
+		"$ref": "#/definitions/book",
+		"definitions": {
+		   "book": {
+			  "required": [
+				 "ID",
+				 "Title",
+				 "Author",
+				 "Meta"
+			  ],
+			  "properties": {
+				 "Author": {
+					"type": "string"
+				 },
+				 "Banned": {
+					"type": "boolean"
+				 },
+				 "ID": {
+					"type": "string"
+				 },
+				 "Meta": {
+					"$schema": "http://json-schema.org/draft-04/schema#",
+					"$ref": "#/definitions/bookStats"
+				 },
+				 "Title": {
+					"type": "string"
+				 }
+			  },
+			  "additionalProperties": false,
+			  "type": "object"
+		   },
+		   "bookStats": {
+			  "required": [
+				 "TotalReads",
+				 "Rating"
+			  ],
+			  "properties": {
+				 "Rating": {
+					"type": "number"
+				 },
+				 "TotalReads": {
+					"type": "integer"
+				 }
+			  },
+			  "additionalProperties": false,
+			  "type": "object"
+		   }
+		}
+	 }`
+)
+
+type jsonQueryTest struct {
+	name    string
+	query   JSONQuery
+	resIdx  []int
+	ordered bool
+}
+
+var (
+	jsonSampleData = []string{
+		`{"ID": "", "Title": "Title1", "Banned": true,  "Author": "Author1", "Meta": { "TotalReads": 100, "Rating": 3.2 }}`,
+		`{"ID": "", "Title": "Title2", "Banned": false, "Author": "Author1", "Meta": { "TotalReads": 150, "Rating": 4.1 }}`,
+		`{"ID": "", "Title": "Title3", "Banned": false, "Author": "Author2", "Meta": { "TotalReads": 120, "Rating": 4.6 }}`,
+		`{"ID": "", "Title": "Title4", "Banned": true,  "Author": "Author3", "Meta": { "TotalReads": 1000, "Rating": 2.6 }}`,
+	}
+
+	boolTrue   = true
+	boolFalse  = false
+	title      = "Title"
+	title0     = "Title1"
+	title1     = "Title2"
+	title3     = "Title3"
+	titleMax   = "Title5000"
+	totreadEq1 = 100.0
+	totreadMid = 124.36
+	totreadEq2 = 150.0
+	totreadMax = 1221.25
+	totreadMin = 12.22
+	ratingMin  = 1.0
+	rating1    = 3.2
+	ratingMid  = 3.6
+	ratingMax  = 5.0
+
+	jsonQueries = []jsonQueryTest{
+		// Ands string
+		jsonQueryTest{
+			name:   "EqByTitle1",
+			resIdx: []int{0},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Title",
+						Operation: Eq,
+						Value: JSONValue{
+							String: &title0,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "NeByTitle1",
+			resIdx: []int{1, 2, 3},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Title",
+						Operation: Ne,
+						Value: JSONValue{
+							String: &title0,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "NeByTitle",
+			resIdx: []int{0, 1, 2, 3},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Title",
+						Operation: Ne,
+						Value: JSONValue{
+							String: &title,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "EqByTitle",
+			resIdx: []int{},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Title",
+						Operation: Eq,
+						Value: JSONValue{
+							String: &title,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "LtByTitle",
+			resIdx: []int{},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Title",
+						Operation: Lt,
+						Value: JSONValue{
+							String: &title,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "GtByTitle",
+			resIdx: []int{0, 1, 2, 3},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Title",
+						Operation: Gt,
+						Value: JSONValue{
+							String: &title,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "GtByTitleMax",
+			resIdx: []int{},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Title",
+						Operation: Gt,
+						Value: JSONValue{
+							String: &titleMax,
+						},
+					},
+				},
+			},
+		},
+
+		// Ands "int" (which query interpret as float)
+		jsonQueryTest{
+			name:   "EqByTotalReads1",
+			resIdx: []int{0},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.TotalReads",
+						Operation: Eq,
+						Value: JSONValue{
+							Float: &totreadEq1,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "LtByTotalReads1",
+			resIdx: []int{},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.TotalReads",
+						Operation: Lt,
+						Value: JSONValue{
+							Float: &totreadEq1,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "LeByTotalReadsBigger",
+			resIdx: []int{0, 1, 2, 3},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.TotalReads",
+						Operation: Le,
+						Value: JSONValue{
+							Float: &totreadMax,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "GeByTotalReadsMin",
+			resIdx: []int{0, 1, 2, 3},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.TotalReads",
+						Operation: Ge,
+						Value: JSONValue{
+							Float: &totreadMin,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "LtByTotalReadsMidpoint",
+			resIdx: []int{0, 2},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.TotalReads",
+						Operation: Lt,
+						Value: JSONValue{
+							Float: &totreadMid,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "GtByTotalReadsMidpoint",
+			resIdx: []int{1, 3},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.TotalReads",
+						Operation: Gt,
+						Value: JSONValue{
+							Float: &totreadMid,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "LtByTotalReads2",
+			resIdx: []int{0, 2},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.TotalReads",
+						Operation: Lt,
+						Value: JSONValue{
+							Float: &totreadEq2,
+						},
+					},
+				},
+			},
+		},
+
+		// Ands float
+		jsonQueryTest{
+			name:   "EqByRating1",
+			resIdx: []int{0},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.Rating",
+						Operation: Eq,
+						Value: JSONValue{
+							Float: &rating1,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "GtByRating1",
+			resIdx: []int{1, 2},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.Rating",
+						Operation: Gt,
+						Value: JSONValue{
+							Float: &rating1,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "LeByRatingMid",
+			resIdx: []int{0, 3},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.Rating",
+						Operation: Le,
+						Value: JSONValue{
+							Float: &ratingMid,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "GeByRatingMid",
+			resIdx: []int{1, 2},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.Rating",
+						Operation: Ge,
+						Value: JSONValue{
+							Float: &ratingMid,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "LeByRatingMax",
+			resIdx: []int{0, 1, 2, 3},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.Rating",
+						Operation: Le,
+						Value: JSONValue{
+							Float: &ratingMax,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "GtByRatingMax",
+			resIdx: []int{},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.Rating",
+						Operation: Gt,
+						Value: JSONValue{
+							Float: &ratingMax,
+						},
+					},
+				},
+			},
+		},
+		// Ands bool
+		jsonQueryTest{
+			name:   "EqByBanned",
+			resIdx: []int{0, 3},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Banned",
+						Operation: Eq,
+						Value: JSONValue{
+							Bool: &boolTrue,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "NeByBanned",
+			resIdx: []int{1, 2},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Banned",
+						Operation: Ne,
+						Value: JSONValue{
+							Bool: &boolTrue,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "EqByBannedFalse",
+			resIdx: []int{1, 2},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Banned",
+						Operation: Eq,
+						Value: JSONValue{
+							Bool: &boolFalse,
+						},
+					},
+				},
+			},
+		},
+
+		// Ors
+		jsonQueryTest{
+			name:   "EqTitle1OrTitle3",
+			resIdx: []int{0, 2},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Title",
+						Operation: Eq,
+						Value: JSONValue{
+							String: &title0,
+						},
+					},
+				},
+				Ors: []JSONQuery{
+					JSONQuery{
+						Ands: []JSONCriterion{
+							JSONCriterion{
+								FieldPath: "Title",
+								Operation: Eq,
+								Value: JSONValue{
+									String: &title3,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "EqTitle2OrRating",
+			resIdx: []int{0, 1},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Title",
+						Operation: Eq,
+						Value: JSONValue{
+							String: &title1,
+						},
+					},
+				},
+				Ors: []JSONQuery{
+					JSONQuery{
+						Ands: []JSONCriterion{
+							JSONCriterion{
+								FieldPath: "Meta.Rating",
+								Operation: Eq,
+								Value: JSONValue{
+									Float: &rating1,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		// Ordering (string, int, float)
+		jsonQueryTest{
+			name:   "AllOrderedTitle",
+			resIdx: []int{0, 1, 2, 3},
+			query: JSONQuery{
+				Sort: JSONSort{
+					FieldPath: "Title",
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "AllOrderedTitleDesc",
+			resIdx: []int{3, 2, 1, 0},
+			query: JSONQuery{
+				Sort: JSONSort{
+					FieldPath: "Title",
+					Desc:      true,
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "AllOrderedTotalReads",
+			resIdx: []int{2, 0, 1, 3},
+			query: JSONQuery{
+				Sort: JSONSort{
+					FieldPath: "Meta.TotalReads",
+					Desc:      false,
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "AllOrderedTotalReads",
+			resIdx: []int{3, 1, 0, 2},
+			query: JSONQuery{
+				Sort: JSONSort{
+					FieldPath: "Meta.TotalReads",
+					Desc:      true,
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "AllOrderedRatings",
+			resIdx: []int{3, 0, 1, 2},
+			query: JSONQuery{
+				Sort: JSONSort{
+					FieldPath: "Meta.TotalReads",
+					Desc:      false,
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "AllOrderedRatingsDesc",
+			resIdx: []int{2, 1, 0, 3},
+			query: JSONQuery{
+				Sort: JSONSort{
+					FieldPath: "Meta.TotalReads",
+					Desc:      true,
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "AllOrderedRatingsDescWithAnd",
+			resIdx: []int{2, 1},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.Rating",
+						Operation: Gt,
+						Value: JSONValue{
+							Float: &ratingMid,
+						},
+					},
+				},
+				Sort: JSONSort{
+					FieldPath: "Meta.TotalReads",
+					Desc:      true,
+				},
+			},
+		},
+	}
+)
+
+func TestQueryJsonMode(t *testing.T) {
+	m, clean := createModelWithJsonData(t)
+	defer clean()
+
+	for _, q := range jsonQueries {
+		q := q
+		t.Run(q.name, func(t *testing.T) {
+			t.Parallel()
+			res, err := m.FindJSON(q.query)
+			checkErr(t, err)
+			if len(q.resIdx) != len(res) {
+				t.Fatalf("query results length doesn't match, expected: %d, got: %d", len(q.resIdx), len(res))
+			}
+			expectedIdx := make([]int, len(q.resIdx))
+			for i := range q.resIdx {
+				expectedIdx[i] = q.resIdx[i]
+			}
+			if !q.ordered {
+				sort.Slice(res, func(i, j int) bool {
+					return strings.Compare(res[i], res[j]) == -1
+				})
+				sort.Slice(expectedIdx, func(i, j int) bool {
+					return strings.Compare(jsonSampleData[expectedIdx[i]], jsonSampleData[expectedIdx[j]]) == -1
+				})
+			}
+			for i, idx := range expectedIdx {
+				if jsonSampleData[idx] != res[i] {
+					t.Fatalf("wrong query item result, expected: %v, got: %v", jsonSampleData[idx], res[i])
+				}
+			}
+		})
+	}
+}
+
+func createModelWithJsonData(t *testing.T) (*Model, func()) {
+	s, clean := createTestStore(t, WithJsonMode(true))
+	m, err := s.RegisterSchema("Book", testQueryJsonModeSchema)
+	checkErr(t, err)
+	for i := range jsonSampleData {
+		if err = m.Create(&jsonSampleData[i]); err != nil {
+			t.Fatalf("failed to create sample data: %v", err)
+		}
+	}
+	return m, clean
+}

--- a/eventstore/query_jsonmode_test.go
+++ b/eventstore/query_jsonmode_test.go
@@ -92,438 +92,438 @@ var (
 	ratingMax  = 5.0
 
 	jsonQueries = []jsonQueryTest{
-		// // Ands string
-		// jsonQueryTest{
-		// 	name:   "EqByTitle1",
-		// 	resIdx: []int{0},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Title",
-		// 				Operation: Eq,
-		// 				Value: JSONValue{
-		// 					String: &title0,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "NeByTitle1",
-		// 	resIdx: []int{1, 2, 3},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Title",
-		// 				Operation: Ne,
-		// 				Value: JSONValue{
-		// 					String: &title0,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "NeByTitle",
-		// 	resIdx: []int{0, 1, 2, 3},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Title",
-		// 				Operation: Ne,
-		// 				Value: JSONValue{
-		// 					String: &title,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "EqByTitle",
-		// 	resIdx: []int{},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Title",
-		// 				Operation: Eq,
-		// 				Value: JSONValue{
-		// 					String: &title,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "LtByTitle",
-		// 	resIdx: []int{},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Title",
-		// 				Operation: Lt,
-		// 				Value: JSONValue{
-		// 					String: &title,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "GtByTitle",
-		// 	resIdx: []int{0, 1, 2, 3},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Title",
-		// 				Operation: Gt,
-		// 				Value: JSONValue{
-		// 					String: &title,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "GtByTitleMax",
-		// 	resIdx: []int{},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Title",
-		// 				Operation: Gt,
-		// 				Value: JSONValue{
-		// 					String: &titleMax,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
+		// Ands string
+		jsonQueryTest{
+			name:   "EqByTitle1",
+			resIdx: []int{0},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Title",
+						Operation: Eq,
+						Value: JSONValue{
+							String: &title0,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "NeByTitle1",
+			resIdx: []int{1, 2, 3},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Title",
+						Operation: Ne,
+						Value: JSONValue{
+							String: &title0,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "NeByTitle",
+			resIdx: []int{0, 1, 2, 3},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Title",
+						Operation: Ne,
+						Value: JSONValue{
+							String: &title,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "EqByTitle",
+			resIdx: []int{},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Title",
+						Operation: Eq,
+						Value: JSONValue{
+							String: &title,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "LtByTitle",
+			resIdx: []int{},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Title",
+						Operation: Lt,
+						Value: JSONValue{
+							String: &title,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "GtByTitle",
+			resIdx: []int{0, 1, 2, 3},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Title",
+						Operation: Gt,
+						Value: JSONValue{
+							String: &title,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "GtByTitleMax",
+			resIdx: []int{},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Title",
+						Operation: Gt,
+						Value: JSONValue{
+							String: &titleMax,
+						},
+					},
+				},
+			},
+		},
 
-		// // Ands "int" (which query interpret as float)
-		// jsonQueryTest{
-		// 	name:   "EqByTotalReads1",
-		// 	resIdx: []int{0},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Meta.TotalReads",
-		// 				Operation: Eq,
-		// 				Value: JSONValue{
-		// 					Float: &totreadEq1,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "LtByTotalReads1",
-		// 	resIdx: []int{},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Meta.TotalReads",
-		// 				Operation: Lt,
-		// 				Value: JSONValue{
-		// 					Float: &totreadEq1,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "LeByTotalReadsBigger",
-		// 	resIdx: []int{0, 1, 2, 3},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Meta.TotalReads",
-		// 				Operation: Le,
-		// 				Value: JSONValue{
-		// 					Float: &totreadMax,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "GeByTotalReadsMin",
-		// 	resIdx: []int{0, 1, 2, 3},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Meta.TotalReads",
-		// 				Operation: Ge,
-		// 				Value: JSONValue{
-		// 					Float: &totreadMin,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "LtByTotalReadsMidpoint",
-		// 	resIdx: []int{0, 2},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Meta.TotalReads",
-		// 				Operation: Lt,
-		// 				Value: JSONValue{
-		// 					Float: &totreadMid,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "GtByTotalReadsMidpoint",
-		// 	resIdx: []int{1, 3},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Meta.TotalReads",
-		// 				Operation: Gt,
-		// 				Value: JSONValue{
-		// 					Float: &totreadMid,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "LtByTotalReads2",
-		// 	resIdx: []int{0, 2},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Meta.TotalReads",
-		// 				Operation: Lt,
-		// 				Value: JSONValue{
-		// 					Float: &totreadEq2,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
+		// Ands "int" (which query interpret as float)
+		jsonQueryTest{
+			name:   "EqByTotalReads1",
+			resIdx: []int{0},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.TotalReads",
+						Operation: Eq,
+						Value: JSONValue{
+							Float: &totreadEq1,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "LtByTotalReads1",
+			resIdx: []int{},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.TotalReads",
+						Operation: Lt,
+						Value: JSONValue{
+							Float: &totreadEq1,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "LeByTotalReadsBigger",
+			resIdx: []int{0, 1, 2, 3},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.TotalReads",
+						Operation: Le,
+						Value: JSONValue{
+							Float: &totreadMax,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "GeByTotalReadsMin",
+			resIdx: []int{0, 1, 2, 3},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.TotalReads",
+						Operation: Ge,
+						Value: JSONValue{
+							Float: &totreadMin,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "LtByTotalReadsMidpoint",
+			resIdx: []int{0, 2},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.TotalReads",
+						Operation: Lt,
+						Value: JSONValue{
+							Float: &totreadMid,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "GtByTotalReadsMidpoint",
+			resIdx: []int{1, 3},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.TotalReads",
+						Operation: Gt,
+						Value: JSONValue{
+							Float: &totreadMid,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "LtByTotalReads2",
+			resIdx: []int{0, 2},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.TotalReads",
+						Operation: Lt,
+						Value: JSONValue{
+							Float: &totreadEq2,
+						},
+					},
+				},
+			},
+		},
 
-		// // Ands float
-		// jsonQueryTest{
-		// 	name:   "EqByRating1",
-		// 	resIdx: []int{0},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Meta.Rating",
-		// 				Operation: Eq,
-		// 				Value: JSONValue{
-		// 					Float: &rating1,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "GtByRating1",
-		// 	resIdx: []int{1, 2},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Meta.Rating",
-		// 				Operation: Gt,
-		// 				Value: JSONValue{
-		// 					Float: &rating1,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "LeByRatingMid",
-		// 	resIdx: []int{0, 3},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Meta.Rating",
-		// 				Operation: Le,
-		// 				Value: JSONValue{
-		// 					Float: &ratingMid,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "GeByRatingMid",
-		// 	resIdx: []int{1, 2},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Meta.Rating",
-		// 				Operation: Ge,
-		// 				Value: JSONValue{
-		// 					Float: &ratingMid,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "LeByRatingMax",
-		// 	resIdx: []int{0, 1, 2, 3},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Meta.Rating",
-		// 				Operation: Le,
-		// 				Value: JSONValue{
-		// 					Float: &ratingMax,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "GtByRatingMax",
-		// 	resIdx: []int{},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Meta.Rating",
-		// 				Operation: Gt,
-		// 				Value: JSONValue{
-		// 					Float: &ratingMax,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// // Ands bool
-		// jsonQueryTest{
-		// 	name:   "EqByBanned",
-		// 	resIdx: []int{0, 3},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Banned",
-		// 				Operation: Eq,
-		// 				Value: JSONValue{
-		// 					Bool: &boolTrue,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "NeByBanned",
-		// 	resIdx: []int{1, 2},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Banned",
-		// 				Operation: Ne,
-		// 				Value: JSONValue{
-		// 					Bool: &boolTrue,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "EqByBannedFalse",
-		// 	resIdx: []int{1, 2},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Banned",
-		// 				Operation: Eq,
-		// 				Value: JSONValue{
-		// 					Bool: &boolFalse,
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
+		// Ands float
+		jsonQueryTest{
+			name:   "EqByRating1",
+			resIdx: []int{0},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.Rating",
+						Operation: Eq,
+						Value: JSONValue{
+							Float: &rating1,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "GtByRating1",
+			resIdx: []int{1, 2},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.Rating",
+						Operation: Gt,
+						Value: JSONValue{
+							Float: &rating1,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "LeByRatingMid",
+			resIdx: []int{0, 3},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.Rating",
+						Operation: Le,
+						Value: JSONValue{
+							Float: &ratingMid,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "GeByRatingMid",
+			resIdx: []int{1, 2},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.Rating",
+						Operation: Ge,
+						Value: JSONValue{
+							Float: &ratingMid,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "LeByRatingMax",
+			resIdx: []int{0, 1, 2, 3},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.Rating",
+						Operation: Le,
+						Value: JSONValue{
+							Float: &ratingMax,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "GtByRatingMax",
+			resIdx: []int{},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.Rating",
+						Operation: Gt,
+						Value: JSONValue{
+							Float: &ratingMax,
+						},
+					},
+				},
+			},
+		},
+		// Ands bool
+		jsonQueryTest{
+			name:   "EqByBanned",
+			resIdx: []int{0, 3},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Banned",
+						Operation: Eq,
+						Value: JSONValue{
+							Bool: &boolTrue,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "NeByBanned",
+			resIdx: []int{1, 2},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Banned",
+						Operation: Ne,
+						Value: JSONValue{
+							Bool: &boolTrue,
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "EqByBannedFalse",
+			resIdx: []int{1, 2},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Banned",
+						Operation: Eq,
+						Value: JSONValue{
+							Bool: &boolFalse,
+						},
+					},
+				},
+			},
+		},
 
-		// // Ors
-		// jsonQueryTest{
-		// 	name:   "EqTitle1OrTitle3",
-		// 	resIdx: []int{0, 2},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Title",
-		// 				Operation: Eq,
-		// 				Value: JSONValue{
-		// 					String: &title0,
-		// 				},
-		// 			},
-		// 		},
-		// 		Ors: []JSONQuery{
-		// 			JSONQuery{
-		// 				Ands: []JSONCriterion{
-		// 					JSONCriterion{
-		// 						FieldPath: "Title",
-		// 						Operation: Eq,
-		// 						Value: JSONValue{
-		// 							String: &title3,
-		// 						},
-		// 					},
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// jsonQueryTest{
-		// 	name:   "EqTitle2OrRating",
-		// 	resIdx: []int{0, 1},
-		// 	query: JSONQuery{
-		// 		Ands: []JSONCriterion{
-		// 			JSONCriterion{
-		// 				FieldPath: "Title",
-		// 				Operation: Eq,
-		// 				Value: JSONValue{
-		// 					String: &title1,
-		// 				},
-		// 			},
-		// 		},
-		// 		Ors: []JSONQuery{
-		// 			JSONQuery{
-		// 				Ands: []JSONCriterion{
-		// 					JSONCriterion{
-		// 						FieldPath: "Meta.Rating",
-		// 						Operation: Eq,
-		// 						Value: JSONValue{
-		// 							Float: &rating1,
-		// 						},
-		// 					},
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
+		// Ors
+		jsonQueryTest{
+			name:   "EqTitle1OrTitle3",
+			resIdx: []int{0, 2},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Title",
+						Operation: Eq,
+						Value: JSONValue{
+							String: &title0,
+						},
+					},
+				},
+				Ors: []JSONQuery{
+					JSONQuery{
+						Ands: []JSONCriterion{
+							JSONCriterion{
+								FieldPath: "Title",
+								Operation: Eq,
+								Value: JSONValue{
+									String: &title3,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		jsonQueryTest{
+			name:   "EqTitle2OrRating",
+			resIdx: []int{0, 1},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Title",
+						Operation: Eq,
+						Value: JSONValue{
+							String: &title1,
+						},
+					},
+				},
+				Ors: []JSONQuery{
+					JSONQuery{
+						Ands: []JSONCriterion{
+							JSONCriterion{
+								FieldPath: "Meta.Rating",
+								Operation: Eq,
+								Value: JSONValue{
+									Float: &rating1,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 
-		// // Ordering (string, int, float)
-		// jsonQueryTest{
-		// 	name:   "AllOrderedTitle",
-		// 	resIdx: []int{0, 1, 2, 3},
-		// 	query: JSONQuery{
-		// 		Sort: JSONSort{
-		// 			FieldPath: "Title",
-		// 		},
-		// 	},
-		// 	ordered: true,
-		// },
-		// jsonQueryTest{
-		// 	name:   "AllOrderedTitleDesc",
-		// 	resIdx: []int{3, 2, 1, 0},
-		// 	query: JSONQuery{
-		// 		Sort: JSONSort{
-		// 			FieldPath: "Title",
-		// 			Desc:      true,
-		// 		},
-		// 	},
-		// 	ordered: true,
-		// },
+		// Ordering (string, int, float)
+		jsonQueryTest{
+			name:   "AllOrderedTitle",
+			resIdx: []int{0, 1, 2, 3},
+			query: JSONQuery{
+				Sort: JSONSort{
+					FieldPath: "Title",
+				},
+			},
+			ordered: true,
+		},
+		jsonQueryTest{
+			name:   "AllOrderedTitleDesc",
+			resIdx: []int{3, 2, 1, 0},
+			query: JSONQuery{
+				Sort: JSONSort{
+					FieldPath: "Title",
+					Desc:      true,
+				},
+			},
+			ordered: true,
+		},
 		jsonQueryTest{
 			name:   "AllOrderedTotalReads",
 			resIdx: []int{0, 2, 1, 3},

--- a/eventstore/query_jsonmode_test.go
+++ b/eventstore/query_jsonmode_test.go
@@ -92,475 +92,481 @@ var (
 	ratingMax  = 5.0
 
 	jsonQueries = []jsonQueryTest{
-		// Ands string
-		jsonQueryTest{
-			name:   "EqByTitle1",
-			resIdx: []int{0},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Title",
-						Operation: Eq,
-						Value: JSONValue{
-							String: &title0,
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "NeByTitle1",
-			resIdx: []int{1, 2, 3},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Title",
-						Operation: Ne,
-						Value: JSONValue{
-							String: &title0,
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "NeByTitle",
-			resIdx: []int{0, 1, 2, 3},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Title",
-						Operation: Ne,
-						Value: JSONValue{
-							String: &title,
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "EqByTitle",
-			resIdx: []int{},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Title",
-						Operation: Eq,
-						Value: JSONValue{
-							String: &title,
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "LtByTitle",
-			resIdx: []int{},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Title",
-						Operation: Lt,
-						Value: JSONValue{
-							String: &title,
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "GtByTitle",
-			resIdx: []int{0, 1, 2, 3},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Title",
-						Operation: Gt,
-						Value: JSONValue{
-							String: &title,
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "GtByTitleMax",
-			resIdx: []int{},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Title",
-						Operation: Gt,
-						Value: JSONValue{
-							String: &titleMax,
-						},
-					},
-				},
-			},
-		},
+		// // Ands string
+		// jsonQueryTest{
+		// 	name:   "EqByTitle1",
+		// 	resIdx: []int{0},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Title",
+		// 				Operation: Eq,
+		// 				Value: JSONValue{
+		// 					String: &title0,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "NeByTitle1",
+		// 	resIdx: []int{1, 2, 3},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Title",
+		// 				Operation: Ne,
+		// 				Value: JSONValue{
+		// 					String: &title0,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "NeByTitle",
+		// 	resIdx: []int{0, 1, 2, 3},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Title",
+		// 				Operation: Ne,
+		// 				Value: JSONValue{
+		// 					String: &title,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "EqByTitle",
+		// 	resIdx: []int{},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Title",
+		// 				Operation: Eq,
+		// 				Value: JSONValue{
+		// 					String: &title,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "LtByTitle",
+		// 	resIdx: []int{},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Title",
+		// 				Operation: Lt,
+		// 				Value: JSONValue{
+		// 					String: &title,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "GtByTitle",
+		// 	resIdx: []int{0, 1, 2, 3},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Title",
+		// 				Operation: Gt,
+		// 				Value: JSONValue{
+		// 					String: &title,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "GtByTitleMax",
+		// 	resIdx: []int{},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Title",
+		// 				Operation: Gt,
+		// 				Value: JSONValue{
+		// 					String: &titleMax,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
 
-		// Ands "int" (which query interpret as float)
-		jsonQueryTest{
-			name:   "EqByTotalReads1",
-			resIdx: []int{0},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Meta.TotalReads",
-						Operation: Eq,
-						Value: JSONValue{
-							Float: &totreadEq1,
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "LtByTotalReads1",
-			resIdx: []int{},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Meta.TotalReads",
-						Operation: Lt,
-						Value: JSONValue{
-							Float: &totreadEq1,
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "LeByTotalReadsBigger",
-			resIdx: []int{0, 1, 2, 3},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Meta.TotalReads",
-						Operation: Le,
-						Value: JSONValue{
-							Float: &totreadMax,
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "GeByTotalReadsMin",
-			resIdx: []int{0, 1, 2, 3},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Meta.TotalReads",
-						Operation: Ge,
-						Value: JSONValue{
-							Float: &totreadMin,
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "LtByTotalReadsMidpoint",
-			resIdx: []int{0, 2},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Meta.TotalReads",
-						Operation: Lt,
-						Value: JSONValue{
-							Float: &totreadMid,
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "GtByTotalReadsMidpoint",
-			resIdx: []int{1, 3},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Meta.TotalReads",
-						Operation: Gt,
-						Value: JSONValue{
-							Float: &totreadMid,
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "LtByTotalReads2",
-			resIdx: []int{0, 2},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Meta.TotalReads",
-						Operation: Lt,
-						Value: JSONValue{
-							Float: &totreadEq2,
-						},
-					},
-				},
-			},
-		},
+		// // Ands "int" (which query interpret as float)
+		// jsonQueryTest{
+		// 	name:   "EqByTotalReads1",
+		// 	resIdx: []int{0},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Meta.TotalReads",
+		// 				Operation: Eq,
+		// 				Value: JSONValue{
+		// 					Float: &totreadEq1,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "LtByTotalReads1",
+		// 	resIdx: []int{},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Meta.TotalReads",
+		// 				Operation: Lt,
+		// 				Value: JSONValue{
+		// 					Float: &totreadEq1,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "LeByTotalReadsBigger",
+		// 	resIdx: []int{0, 1, 2, 3},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Meta.TotalReads",
+		// 				Operation: Le,
+		// 				Value: JSONValue{
+		// 					Float: &totreadMax,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "GeByTotalReadsMin",
+		// 	resIdx: []int{0, 1, 2, 3},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Meta.TotalReads",
+		// 				Operation: Ge,
+		// 				Value: JSONValue{
+		// 					Float: &totreadMin,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "LtByTotalReadsMidpoint",
+		// 	resIdx: []int{0, 2},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Meta.TotalReads",
+		// 				Operation: Lt,
+		// 				Value: JSONValue{
+		// 					Float: &totreadMid,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "GtByTotalReadsMidpoint",
+		// 	resIdx: []int{1, 3},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Meta.TotalReads",
+		// 				Operation: Gt,
+		// 				Value: JSONValue{
+		// 					Float: &totreadMid,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "LtByTotalReads2",
+		// 	resIdx: []int{0, 2},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Meta.TotalReads",
+		// 				Operation: Lt,
+		// 				Value: JSONValue{
+		// 					Float: &totreadEq2,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
 
-		// Ands float
-		jsonQueryTest{
-			name:   "EqByRating1",
-			resIdx: []int{0},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Meta.Rating",
-						Operation: Eq,
-						Value: JSONValue{
-							Float: &rating1,
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "GtByRating1",
-			resIdx: []int{1, 2},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Meta.Rating",
-						Operation: Gt,
-						Value: JSONValue{
-							Float: &rating1,
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "LeByRatingMid",
-			resIdx: []int{0, 3},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Meta.Rating",
-						Operation: Le,
-						Value: JSONValue{
-							Float: &ratingMid,
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "GeByRatingMid",
-			resIdx: []int{1, 2},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Meta.Rating",
-						Operation: Ge,
-						Value: JSONValue{
-							Float: &ratingMid,
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "LeByRatingMax",
-			resIdx: []int{0, 1, 2, 3},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Meta.Rating",
-						Operation: Le,
-						Value: JSONValue{
-							Float: &ratingMax,
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "GtByRatingMax",
-			resIdx: []int{},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Meta.Rating",
-						Operation: Gt,
-						Value: JSONValue{
-							Float: &ratingMax,
-						},
-					},
-				},
-			},
-		},
-		// Ands bool
-		jsonQueryTest{
-			name:   "EqByBanned",
-			resIdx: []int{0, 3},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Banned",
-						Operation: Eq,
-						Value: JSONValue{
-							Bool: &boolTrue,
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "NeByBanned",
-			resIdx: []int{1, 2},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Banned",
-						Operation: Ne,
-						Value: JSONValue{
-							Bool: &boolTrue,
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "EqByBannedFalse",
-			resIdx: []int{1, 2},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Banned",
-						Operation: Eq,
-						Value: JSONValue{
-							Bool: &boolFalse,
-						},
-					},
-				},
-			},
-		},
+		// // Ands float
+		// jsonQueryTest{
+		// 	name:   "EqByRating1",
+		// 	resIdx: []int{0},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Meta.Rating",
+		// 				Operation: Eq,
+		// 				Value: JSONValue{
+		// 					Float: &rating1,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "GtByRating1",
+		// 	resIdx: []int{1, 2},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Meta.Rating",
+		// 				Operation: Gt,
+		// 				Value: JSONValue{
+		// 					Float: &rating1,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "LeByRatingMid",
+		// 	resIdx: []int{0, 3},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Meta.Rating",
+		// 				Operation: Le,
+		// 				Value: JSONValue{
+		// 					Float: &ratingMid,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "GeByRatingMid",
+		// 	resIdx: []int{1, 2},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Meta.Rating",
+		// 				Operation: Ge,
+		// 				Value: JSONValue{
+		// 					Float: &ratingMid,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "LeByRatingMax",
+		// 	resIdx: []int{0, 1, 2, 3},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Meta.Rating",
+		// 				Operation: Le,
+		// 				Value: JSONValue{
+		// 					Float: &ratingMax,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "GtByRatingMax",
+		// 	resIdx: []int{},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Meta.Rating",
+		// 				Operation: Gt,
+		// 				Value: JSONValue{
+		// 					Float: &ratingMax,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// // Ands bool
+		// jsonQueryTest{
+		// 	name:   "EqByBanned",
+		// 	resIdx: []int{0, 3},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Banned",
+		// 				Operation: Eq,
+		// 				Value: JSONValue{
+		// 					Bool: &boolTrue,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "NeByBanned",
+		// 	resIdx: []int{1, 2},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Banned",
+		// 				Operation: Ne,
+		// 				Value: JSONValue{
+		// 					Bool: &boolTrue,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "EqByBannedFalse",
+		// 	resIdx: []int{1, 2},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Banned",
+		// 				Operation: Eq,
+		// 				Value: JSONValue{
+		// 					Bool: &boolFalse,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
 
-		// Ors
-		jsonQueryTest{
-			name:   "EqTitle1OrTitle3",
-			resIdx: []int{0, 2},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Title",
-						Operation: Eq,
-						Value: JSONValue{
-							String: &title0,
-						},
-					},
-				},
-				Ors: []JSONQuery{
-					JSONQuery{
-						Ands: []JSONCriterion{
-							JSONCriterion{
-								FieldPath: "Title",
-								Operation: Eq,
-								Value: JSONValue{
-									String: &title3,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "EqTitle2OrRating",
-			resIdx: []int{0, 1},
-			query: JSONQuery{
-				Ands: []JSONCriterion{
-					JSONCriterion{
-						FieldPath: "Title",
-						Operation: Eq,
-						Value: JSONValue{
-							String: &title1,
-						},
-					},
-				},
-				Ors: []JSONQuery{
-					JSONQuery{
-						Ands: []JSONCriterion{
-							JSONCriterion{
-								FieldPath: "Meta.Rating",
-								Operation: Eq,
-								Value: JSONValue{
-									Float: &rating1,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
+		// // Ors
+		// jsonQueryTest{
+		// 	name:   "EqTitle1OrTitle3",
+		// 	resIdx: []int{0, 2},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Title",
+		// 				Operation: Eq,
+		// 				Value: JSONValue{
+		// 					String: &title0,
+		// 				},
+		// 			},
+		// 		},
+		// 		Ors: []JSONQuery{
+		// 			JSONQuery{
+		// 				Ands: []JSONCriterion{
+		// 					JSONCriterion{
+		// 						FieldPath: "Title",
+		// 						Operation: Eq,
+		// 						Value: JSONValue{
+		// 							String: &title3,
+		// 						},
+		// 					},
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// jsonQueryTest{
+		// 	name:   "EqTitle2OrRating",
+		// 	resIdx: []int{0, 1},
+		// 	query: JSONQuery{
+		// 		Ands: []JSONCriterion{
+		// 			JSONCriterion{
+		// 				FieldPath: "Title",
+		// 				Operation: Eq,
+		// 				Value: JSONValue{
+		// 					String: &title1,
+		// 				},
+		// 			},
+		// 		},
+		// 		Ors: []JSONQuery{
+		// 			JSONQuery{
+		// 				Ands: []JSONCriterion{
+		// 					JSONCriterion{
+		// 						FieldPath: "Meta.Rating",
+		// 						Operation: Eq,
+		// 						Value: JSONValue{
+		// 							Float: &rating1,
+		// 						},
+		// 					},
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
 
-		// Ordering (string, int, float)
-		jsonQueryTest{
-			name:   "AllOrderedTitle",
-			resIdx: []int{0, 1, 2, 3},
-			query: JSONQuery{
-				Sort: JSONSort{
-					FieldPath: "Title",
-				},
-			},
-		},
-		jsonQueryTest{
-			name:   "AllOrderedTitleDesc",
-			resIdx: []int{3, 2, 1, 0},
-			query: JSONQuery{
-				Sort: JSONSort{
-					FieldPath: "Title",
-					Desc:      true,
-				},
-			},
-		},
+		// // Ordering (string, int, float)
+		// jsonQueryTest{
+		// 	name:   "AllOrderedTitle",
+		// 	resIdx: []int{0, 1, 2, 3},
+		// 	query: JSONQuery{
+		// 		Sort: JSONSort{
+		// 			FieldPath: "Title",
+		// 		},
+		// 	},
+		// 	ordered: true,
+		// },
+		// jsonQueryTest{
+		// 	name:   "AllOrderedTitleDesc",
+		// 	resIdx: []int{3, 2, 1, 0},
+		// 	query: JSONQuery{
+		// 		Sort: JSONSort{
+		// 			FieldPath: "Title",
+		// 			Desc:      true,
+		// 		},
+		// 	},
+		// 	ordered: true,
+		// },
 		jsonQueryTest{
 			name:   "AllOrderedTotalReads",
-			resIdx: []int{2, 0, 1, 3},
+			resIdx: []int{0, 2, 1, 3},
 			query: JSONQuery{
 				Sort: JSONSort{
 					FieldPath: "Meta.TotalReads",
 					Desc:      false,
 				},
 			},
+			ordered: true,
 		},
 		jsonQueryTest{
 			name:   "AllOrderedTotalReads",
-			resIdx: []int{3, 1, 0, 2},
+			resIdx: []int{3, 1, 2, 0},
 			query: JSONQuery{
 				Sort: JSONSort{
 					FieldPath: "Meta.TotalReads",
 					Desc:      true,
 				},
 			},
+			ordered: true,
 		},
 		jsonQueryTest{
 			name:   "AllOrderedRatings",
 			resIdx: []int{3, 0, 1, 2},
 			query: JSONQuery{
 				Sort: JSONSort{
-					FieldPath: "Meta.TotalReads",
+					FieldPath: "Meta.Rating",
 					Desc:      false,
 				},
 			},
+			ordered: true,
 		},
 		jsonQueryTest{
 			name:   "AllOrderedRatingsDesc",
 			resIdx: []int{2, 1, 0, 3},
 			query: JSONQuery{
 				Sort: JSONSort{
-					FieldPath: "Meta.TotalReads",
+					FieldPath: "Meta.Rating",
 					Desc:      true,
 				},
 			},
+			ordered: true,
 		},
 		jsonQueryTest{
 			name:   "AllOrderedRatingsDescWithAnd",
@@ -577,9 +583,30 @@ var (
 				},
 				Sort: JSONSort{
 					FieldPath: "Meta.TotalReads",
+					Desc:      false,
+				},
+			},
+			ordered: true,
+		},
+		jsonQueryTest{
+			name:   "AllOrderedRatingsDescWithAndDesc",
+			resIdx: []int{1, 2},
+			query: JSONQuery{
+				Ands: []JSONCriterion{
+					JSONCriterion{
+						FieldPath: "Meta.Rating",
+						Operation: Gt,
+						Value: JSONValue{
+							Float: &ratingMid,
+						},
+					},
+				},
+				Sort: JSONSort{
+					FieldPath: "Meta.TotalReads",
 					Desc:      true,
 				},
 			},
+			ordered: true,
 		},
 	}
 )

--- a/eventstore/query_test.go
+++ b/eventstore/query_test.go
@@ -105,7 +105,7 @@ func TestModelQuery(t *testing.T) {
 			t.Parallel()
 			var res []*book
 			if err := m.Find(&res, q.query); err != nil {
-				t.Fatal("error when executing query")
+				t.Fatalf("error when executing query: %v", err)
 			}
 			if len(q.resIdx) != len(res) {
 				t.Fatalf("query results length doesn't match, expected: %d, got: %d", len(q.resIdx), len(res))


### PR DESCRIPTION
New API for making queries in JSON Mode.

It receives a serializable struct and will return a slice of string which are the json values of the instances of the query.

Created #131 with some further comments about some impact of this new JSONMode feature. I guess that's something to evaluate more in the future, but we all have it somewhat present in our minds.

Comments below.