### PR TITLE
threads: fix concurrency

### DIFF
--- a/client.go
+++ b/client.go
@@ -139,6 +139,12 @@ func (r *records) Store(p peer.ID, key cid.Cid, value thread.Record) {
 		return
 	}
 	r.m[p][key] = value
+
+	// Sanity check
+	if len(r.s[p]) > 0 && r.s[p][len(r.s[p])-1].Cid() != value.PrevID() {
+		panic("there is a gap in records list")
+	}
+
 	r.s[p] = append(r.s[p], value)
 }
 
@@ -189,8 +195,7 @@ func (s *service) getRecords(
 	wg := sync.WaitGroup{}
 	for _, addr := range lg.Addrs {
 		wg.Add(1)
-		// ToDo: fix concurrency
-		func(addr ma.Multiaddr) {
+		go func(addr ma.Multiaddr) {
 			defer wg.Done()
 			p, err := addr.ValueForProtocol(ma.P_P2P)
 			if err != nil {
@@ -221,7 +226,6 @@ func (s *service) getRecords(
 				log.Warningf("get records from %s failed: %s", p, err)
 				return
 			}
-
 			for _, l := range reply.Logs {
 				log.Debugf("received %d records in log %s from %s", len(l.Records), l.LogID.ID.String(), p)
 
@@ -233,6 +237,20 @@ func (s *service) getRecords(
 				if lg.PubKey == nil {
 					if l.Log != nil {
 						lg = logFromProto(l.Log)
+
+						// (jsign): problem here. a priori this method isn't guaranteed to be
+						// guarded per-thread, so this `AddLog` might be wrong.
+						// Moreover, has a similar problem with was was done in `service.go`,
+						// it will set the current (created) log head to the value received,
+						// without giving guarantees of having that record (or any previous missing ones)
+						// I think all thread logic should never be on `service.go` or `client.go`, and always
+						// on `threads.go`, so we can be sure that all methods there are properly guarded.
+						// Or add the method comment: `this method *must be thread-guarded*`
+						//
+						// As a workaround until having some confirmation, the following line is a
+						// workaround to at least  set current head to empty. Whoever called this method should
+						// `putRecords` considering the mentioned external peer head.
+						lg.Heads = []cid.Cid{}
 						if err = s.threads.store.AddLog(id, lg); err != nil {
 							log.Error(err)
 							return
@@ -307,7 +325,7 @@ func (s *service) pushRecord(ctx context.Context, id thread.ID, lid peer.ID, rec
 	wg := sync.WaitGroup{}
 	for _, addr := range addrs {
 		wg.Add(1)
-		go func(addr ma.Multiaddr) {
+		func(addr ma.Multiaddr) {
 			defer wg.Done()
 			p, err := addr.ValueForProtocol(ma.P_P2P)
 			if err != nil {

--- a/client.go
+++ b/client.go
@@ -312,7 +312,7 @@ func (s *service) pushRecord(ctx context.Context, id thread.ID, lid peer.ID, rec
 	wg := sync.WaitGroup{}
 	for _, addr := range addrs {
 		wg.Add(1)
-		func(addr ma.Multiaddr) {
+		go func(addr ma.Multiaddr) {
 			defer wg.Done()
 			p, err := addr.ValueForProtocol(ma.P_P2P)
 			if err != nil {

--- a/client.go
+++ b/client.go
@@ -237,19 +237,6 @@ func (s *service) getRecords(
 				if lg.PubKey == nil {
 					if l.Log != nil {
 						lg = logFromProto(l.Log)
-
-						// (jsign): problem here. a priori this method isn't guaranteed to be
-						// guarded per-thread, so this `AddLog` might be wrong.
-						// Moreover, has a similar problem with was was done in `service.go`,
-						// it will set the current (created) log head to the value received,
-						// without giving guarantees of having that record (or any previous missing ones)
-						// I think all thread logic should never be on `service.go` or `client.go`, and always
-						// on `threads.go`, so we can be sure that all methods there are properly guarded.
-						// Or add the method comment: `this method *must be thread-guarded*`
-						//
-						// As a workaround until having some confirmation, the following line is a
-						// workaround to at least  set current head to empty. Whoever called this method should
-						// `putRecords` considering the mentioned external peer head.
 						lg.Heads = []cid.Cid{}
 						if err = s.threads.store.AddLog(id, lg); err != nil {
 							log.Error(err)

--- a/eventstore/util.go
+++ b/eventstore/util.go
@@ -32,6 +32,7 @@ const (
 // sane defaults.
 type ThreadserviceBoostrapper interface {
 	tserv.Threadservice
+	GetIpfsLite() *ipfslite.Peer
 	Bootstrap(addrs []peer.AddrInfo)
 }
 
@@ -160,6 +161,10 @@ var _ ThreadserviceBoostrapper = (*tservBoostrapper)(nil)
 
 func (tsb *tservBoostrapper) Bootstrap(addrs []peer.AddrInfo) {
 	tsb.litepeer.Bootstrap(addrs)
+}
+
+func (tsb *tservBoostrapper) GetIpfsLite() *ipfslite.Peer {
+	return tsb.litepeer
 }
 
 func (tsb *tservBoostrapper) Close() error {

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/libp2p/go-libp2p-connmgr v0.1.1
 	github.com/libp2p/go-libp2p-core v0.2.3
 	github.com/libp2p/go-libp2p-gostream v0.2.0
-	github.com/libp2p/go-libp2p-kad-dht v0.3.0 // indirect
+	github.com/libp2p/go-libp2p-kad-dht v0.3.0
 	github.com/libp2p/go-libp2p-peerstore v0.1.3
 	github.com/libp2p/go-libp2p-pubsub v0.1.1
 	github.com/libp2p/go-libp2p-swarm v0.2.2

--- a/service.go
+++ b/service.go
@@ -120,8 +120,7 @@ func (s *service) PushLog(ctx context.Context, req *pb.PushLogRequest) (*pb.Push
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	// Fix concurrency
-	s.threads.updateRecordsFromLog(req.ThreadID.ID, lg.ID)
+	go s.threads.updateRecordsFromLog(req.ThreadID.ID, lg.ID)
 
 	return &pb.PushLogReply{}, nil
 }

--- a/threads.go
+++ b/threads.go
@@ -267,7 +267,6 @@ func (t *threads) AddThread(
 	// @todo: ensure does not exist? or overwrite with newer info from owner?
 	for _, l := range lgs {
 		if err = t.createExternalLogIfNotExist(id, l.ID, l.PubKey, l.PrivKey, l.Addrs); err != nil {
-			//if err = t.store.AddLog(id, l); err != nil {
 			return
 		}
 	}
@@ -464,7 +463,6 @@ func (t *threads) AddRecord(ctx context.Context, id thread.ID, body format.Node)
 		threadID: id,
 		logID:    lg.ID,
 	}
-	fmt.Printf("Host %s adding cid %s\n", t.Host().ID(), r.Value().Cid())
 	if err = t.bus.SendWithTimeout(r, time.Second*10); err != nil {
 		return
 	}
@@ -583,10 +581,8 @@ func (t *threads) putRecord(ctx context.Context, id thread.ID, lid peer.ID, rec 
 			return err
 		}
 		if exist {
-			fmt.Printf("In host %s KNOWN cid %s\n", t.Host().ID(), cid)
 			break
 		}
-		fmt.Printf("In host %s unkown %s\n", t.Host().ID(), cid)
 		r, err := t.GetRecord(ctx, id, cid)
 		if err != nil {
 			return err

--- a/threads.go
+++ b/threads.go
@@ -466,7 +466,7 @@ func (t *threads) AddRecord(ctx context.Context, id thread.ID, body format.Node)
 		threadID: id,
 		logID:    lg.ID,
 	}
-	if err = t.bus.SendWithTimeout(r, time.Second*10); err != nil {
+	if err = t.bus.SendWithTimeout(r, time.Second*3); err != nil {
 		return
 	}
 

--- a/threads.go
+++ b/threads.go
@@ -597,7 +597,7 @@ func (t *threads) putRecord(ctx context.Context, id thread.ID, lid peer.ID, rec 
 		return nil
 	}
 	// Get or create a log for the new rec
-	lg, err := util.GetOrCreateLog(t, id, lid)
+	lg, err := util.GetLog(t, id, lid)
 	if err != nil {
 		return err
 	}

--- a/threads.go
+++ b/threads.go
@@ -263,9 +263,11 @@ func (t *threads) AddThread(
 	if err != nil {
 		return
 	}
+
 	// @todo: ensure does not exist? or overwrite with newer info from owner?
 	for _, l := range lgs {
-		if err = t.store.AddLog(id, l); err != nil {
+		if err = t.createExternalLogIfNotExist(id, l.ID, l.PubKey, l.PrivKey, l.Addrs); err != nil {
+			//if err = t.store.AddLog(id, l); err != nil {
 			return
 		}
 	}
@@ -294,65 +296,74 @@ func (t *threads) getThreadSemaphore(id thread.ID) chan struct{} {
 // PullThread for new records.
 // Logs owned by this host are traversed locally.
 // Remotely addressed logs are pulled from the network.
+// Is thread-safe.
 func (t *threads) PullThread(ctx context.Context, id thread.ID) error {
 	log.Debugf("pulling thread %s...", id.String())
 	ptl := t.getThreadSemaphore(id)
-	// Fix concurrency, temporary global lock
-	t.pullLock.Lock()
-	defer t.pullLock.Unlock()
 	select {
 	case ptl <- struct{}{}:
-		lgs, err := t.getLogs(id)
+		err := t.pullThread(ctx, id)
 		if err != nil {
+			<-ptl
 			return err
 		}
-
-		// Gather offsets for each log
-		offsets := make(map[peer.ID]cid.Cid)
-		for _, lg := range lgs {
-			offsets[lg.ID] = cid.Undef
-			if len(lg.Heads) > 0 {
-				has, err := t.bstore.Has(lg.Heads[0])
-				if err != nil {
-					return err
-				}
-				if has {
-					offsets[lg.ID] = lg.Heads[0]
-				}
-			}
-		}
-		wg := sync.WaitGroup{}
-		for _, lg := range lgs {
-			wg.Add(1)
-			// ToDo: fix concurrency
-			func(lg thread.LogInfo) {
-				defer wg.Done()
-				// Pull from addresses
-				recs, err := t.service.getRecords(
-					ctx,
-					id,
-					lg.ID,
-					offsets,
-					MaxPullLimit)
-				if err != nil {
-					log.Error(err)
-					return
-				}
-				for lid, rs := range recs {
-					for _, r := range rs {
-						if err = t.putRecord(ctx, id, lid, r); err != nil {
-							log.Error(err)
-							return
-						}
-					}
-				}
-			}(lg)
-		}
-		wg.Wait()
 		<-ptl
 	default:
 		log.Warningf("pull thread %s ignored since already being pulled", id)
 	}
+	return nil
+}
+
+// pullThread for new records. It's internal and *not* thread-safe,
+// it assumes we currently own the thread-lock.
+func (t *threads) pullThread(ctx context.Context, id thread.ID) error {
+	lgs, err := t.getLogs(id)
+	if err != nil {
+		return err
+	}
+
+	// Gather offsets for each log
+	offsets := make(map[peer.ID]cid.Cid)
+	for _, lg := range lgs {
+		offsets[lg.ID] = cid.Undef
+		if len(lg.Heads) > 0 {
+			has, err := t.bstore.Has(lg.Heads[0])
+			if err != nil {
+				return err
+			}
+			if has {
+				offsets[lg.ID] = lg.Heads[0]
+			}
+		}
+	}
+	wg := sync.WaitGroup{}
+	for _, lg := range lgs {
+		wg.Add(1)
+		// ToDo: fix concurrency
+		func(lg thread.LogInfo) {
+			defer wg.Done()
+			// Pull from addresses
+			recs, err := t.service.getRecords(
+				ctx,
+				id,
+				lg.ID,
+				offsets,
+				MaxPullLimit)
+			if err != nil {
+				log.Error(err)
+				return
+			}
+			for lid, rs := range recs {
+				for _, r := range rs {
+					if err = t.putRecord(ctx, id, lid, r); err != nil {
+						log.Error(err)
+						return
+					}
+				}
+			}
+		}(lg)
+	}
+	wg.Wait()
 	return nil
 }
 
@@ -453,7 +464,8 @@ func (t *threads) AddRecord(ctx context.Context, id thread.ID, body format.Node)
 		threadID: id,
 		logID:    lg.ID,
 	}
-	if err = t.bus.SendWithTimeout(r, time.Second); err != nil {
+	fmt.Printf("Host %s adding cid %s\n", t.Host().ID(), r.Value().Cid())
+	if err = t.bus.SendWithTimeout(r, time.Second*10); err != nil {
 		return
 	}
 
@@ -552,7 +564,16 @@ func (t *threads) Subscribe(opts ...options.SubOption) tserv.Subscription {
 	return listener
 }
 
+// PutRecord adds an existing record. This method is thread-safe
+func (t *threads) PutRecord(ctx context.Context, id thread.ID, lid peer.ID, rec thread.Record) error {
+	tsph := t.getThreadSemaphore(id)
+	tsph <- struct{}{}
+	defer func() { <-tsph }()
+	return t.putRecord(ctx, id, lid, rec)
+}
+
 // putRecord adds an existing record. See PutOption for more.
+// This method *should be thread-guarded*
 func (t *threads) putRecord(ctx context.Context, id thread.ID, lid peer.ID, rec thread.Record) error {
 	unknownRecords := []thread.Record{}
 	cid := rec.Cid()
@@ -562,8 +583,10 @@ func (t *threads) putRecord(ctx context.Context, id thread.ID, lid peer.ID, rec 
 			return err
 		}
 		if exist {
+			fmt.Printf("In host %s KNOWN cid %s\n", t.Host().ID(), cid)
 			break
 		}
+		fmt.Printf("In host %s unkown %s\n", t.Host().ID(), cid)
 		r, err := t.GetRecord(ctx, id, cid)
 		if err != nil {
 			return err
@@ -574,7 +597,6 @@ func (t *threads) putRecord(ctx context.Context, id thread.ID, lid peer.ID, rec 
 	if len(unknownRecords) == 0 {
 		return nil
 	}
-
 	// Get or create a log for the new rec
 	lg, err := util.GetOrCreateLog(t, id, lid)
 	if err != nil {
@@ -616,14 +638,14 @@ func (t *threads) putRecord(ctx context.Context, id thread.ID, lid peer.ID, rec 
 			Record:   r,
 			threadID: id,
 			logID:    lg.ID,
-		}, time.Second)
+		}, time.Second*5)
 		if err != nil {
 			return err
 		}
-	}
-	// Update head
-	if err = t.store.SetHead(id, lg.ID, unknownRecords[0].Cid()); err != nil {
-		return err
+		// Update head
+		if err = t.store.SetHead(id, lg.ID, r.Cid()); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -760,8 +782,7 @@ func (t *threads) startPulling() {
 			return
 		}
 		for _, id := range ts {
-			// ToDo: fix concurrency
-			func(id thread.ID) {
+			go func(id thread.ID) {
 				if err := t.PullThread(t.ctx, id); err != nil {
 					log.Errorf("error pulling thread %s: %s", id.String(), err)
 				}
@@ -785,6 +806,59 @@ func (t *threads) startPulling() {
 			pull()
 		case <-t.ctx.Done():
 			return
+		}
+	}
+}
+
+// createExternalLogIfNotExist creates an external log if doesn't exists. The created
+// log will have cid.Undef as the current head. Is thread-safe.
+func (t *threads) createExternalLogIfNotExist(tid thread.ID, lid peer.ID, pubKey ic.PubKey,
+	privKey ic.PrivKey, addrs []ma.Multiaddr) error {
+	tsph := t.getThreadSemaphore(tid)
+	tsph <- struct{}{}
+	defer func() { <-tsph }()
+	currHeads, err := t.Store().Heads(tid, lid)
+	if err != nil {
+		return err
+	}
+	if len(currHeads) == 0 {
+		lginfo := thread.LogInfo{
+			ID:      lid,
+			PubKey:  pubKey,
+			PrivKey: privKey,
+			Addrs:   addrs,
+			Heads:   []cid.Cid{},
+		}
+		if err := t.store.AddLog(tid, lginfo); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// updateRecordsFromLog will fetch lid addrs for new logs & records,
+// and will add them in the local peer store. It assumes  Is thread-safe.
+func (t *threads) updateRecordsFromLog(tid thread.ID, lid peer.ID) {
+	tsph := t.getThreadSemaphore(tid)
+	tsph <- struct{}{}
+	defer func() { <-tsph }()
+	// Get log records for this new log
+	recs, err := t.service.getRecords(
+		t.ctx,
+		tid,
+		lid,
+		map[peer.ID]cid.Cid{lid: cid.Undef}, // (jsign): shouldn't this be current head?
+		MaxPullLimit)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	for lid, rs := range recs { // ToDo: verify if they're ordered since this will optimize
+		for _, r := range rs {
+			if err = t.putRecord(t.ctx, tid, lid, r); err != nil {
+				log.Error(err)
+				return
+			}
 		}
 	}
 }

--- a/threads.go
+++ b/threads.go
@@ -758,7 +758,7 @@ func (t *threads) getLocalRecords(
 		if !cursor.Defined() || cursor.String() == offset.String() {
 			break
 		}
-		r, err := cbor.GetRecord(ctx, t, cursor, fk)
+		r, err := cbor.GetRecord(ctx, t, cursor, fk) // Important invariant: heads are always in blockstore
 		if err != nil {
 			return nil, err
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -45,7 +45,7 @@ func CreateThread(t tserv.Threadservice, id thread.ID) (info thread.Info, err er
 }
 
 // CreateLog creates a new log with the given peer as host.
-func CreateLog(host peer.ID) (info thread.LogInfo, err error) { // (jsign): Would be beter to rename CreateLocalLog?
+func CreateLog(host peer.ID) (info thread.LogInfo, err error) {
 	sk, pk, err := ic.GenerateEd25519Key(rand.Reader)
 	if err != nil {
 		return
@@ -70,9 +70,6 @@ func CreateLog(host peer.ID) (info thread.LogInfo, err error) { // (jsign): Woul
 // GetOrCreateLog returns the log with the given thread and log id.
 // If no log exists, a new one is created under the given thread.
 func GetOrCreateLog(t tserv.Threadservice, id thread.ID, lid peer.ID) (info thread.LogInfo, err error) {
-	// (jsign): Better rename to `GetOrCreateLocalLog`?. I find weird that if lid doesn't
-	// exist, then a new log is created ignoring completely `lid` value. Isn't wierd?
-	// Maybe the idea was create the log but with the `lid` (with no addrs & no heads)
 	info, err = t.Store().LogInfo(id, lid)
 	if err != nil {
 		return

--- a/util/util.go
+++ b/util/util.go
@@ -45,7 +45,7 @@ func CreateThread(t tserv.Threadservice, id thread.ID) (info thread.Info, err er
 }
 
 // CreateLog creates a new log with the given peer as host.
-func CreateLog(host peer.ID) (info thread.LogInfo, err error) {
+func CreateLog(host peer.ID) (info thread.LogInfo, err error) { // (jsign): Would be beter to rename CreateLocalLog?
 	sk, pk, err := ic.GenerateEd25519Key(rand.Reader)
 	if err != nil {
 		return
@@ -70,6 +70,9 @@ func CreateLog(host peer.ID) (info thread.LogInfo, err error) {
 // GetOrCreateLog returns the log with the given thread and log id.
 // If no log exists, a new one is created under the given thread.
 func GetOrCreateLog(t tserv.Threadservice, id thread.ID, lid peer.ID) (info thread.LogInfo, err error) {
+	// (jsign): Better rename to `GetOrCreateLocalLog`?. I find weird that if lid doesn't
+	// exist, then a new log is created ignoring completely `lid` value. Isn't wierd?
+	// Maybe the idea was create the log but with the `lid` (with no addrs & no heads)
 	info, err = t.Store().LogInfo(id, lid)
 	if err != nil {
 		return
@@ -77,6 +80,7 @@ func GetOrCreateLog(t tserv.Threadservice, id thread.ID, lid peer.ID) (info thre
 	if info.PubKey != nil {
 		return
 	}
+	panic("WHAT")
 	info, err = CreateLog(t.Host().ID())
 	if err != nil {
 		return

--- a/util/util.go
+++ b/util/util.go
@@ -80,7 +80,6 @@ func GetOrCreateLog(t tserv.Threadservice, id thread.ID, lid peer.ID) (info thre
 	if info.PubKey != nil {
 		return
 	}
-	panic("WHAT")
 	info, err = CreateLog(t.Host().ID())
 	if err != nil {
 		return

--- a/util/util.go
+++ b/util/util.go
@@ -77,7 +77,7 @@ func GetOrCreateLog(t tserv.Threadservice, id thread.ID, lid peer.ID) (info thre
 	if info.PubKey != nil {
 		return
 	}
-	info, err = CreateLog(t.Host().ID())
+	info, err = CreateLog(t.Host().ID()) // ToDo: is this correct?
 	if err != nil {
 		return
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"crypto/rand"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -67,9 +68,8 @@ func CreateLog(host peer.ID) (info thread.LogInfo, err error) {
 	}, nil
 }
 
-// GetOrCreateLog returns the log with the given thread and log id.
-// If no log exists, a new one is created under the given thread.
-func GetOrCreateLog(t tserv.Threadservice, id thread.ID, lid peer.ID) (info thread.LogInfo, err error) {
+// GetLog returns the log with the given thread and log id.
+func GetLog(t tserv.Threadservice, id thread.ID, lid peer.ID) (info thread.LogInfo, err error) {
 	info, err = t.Store().LogInfo(id, lid)
 	if err != nil {
 		return
@@ -77,12 +77,7 @@ func GetOrCreateLog(t tserv.Threadservice, id thread.ID, lid peer.ID) (info thre
 	if info.PubKey != nil {
 		return
 	}
-	info, err = CreateLog(t.Host().ID()) // ToDo: is this correct?
-	if err != nil {
-		return
-	}
-	err = t.Store().AddLog(id, info)
-	return
+	return info, fmt.Errorf("log %s doesn't exist for thread %s", lid, id)
 }
 
 // GetOwnLoad returns the log owned by the host under the given thread.


### PR DESCRIPTION
Fixes #121 

The main idea of this PR is enabling concurrency per-thread without problems. 

The way to think the concurrency thing is the following:
- `threads` has a `getThreadSemaphore(thread.ID)` which returns a 1-buffered channel that acts as a mutex. The reason for being a channel and not a mutex is that operations can choose to dismiss the action and move on, e.g:
   -  `PullThread`, if trying to acquire the channel lock blocks, then it will choose to move on and ignore the action because it means that other work is being done on a thread. Most probably is another pull (can be other things). Whoever called (most probably a ticker) will retry later.
   - Almost all other operations that involve changing data from a thread, will acquire the channel and use it like a mutex (with no dismissal because they should get the work done before returning).
   - Some read-only operations don't need to acquire the channel lock. What makes this safe is that getting the thread or log information should be always safe considering how the theadstore works. Any heads discovered by reading thread-info should be *already* fetched in the blockstore (and available). First blocks are fetched, *then* head is set. (if done inversely, the read operations wouldn't be safe, because they could report a head that we still don't have).
- All thread-locking is done at `threads.go`, not in `service.go` nor `client.go`. This to keep things more easy to reason about, since `threads.go` methods are called in different ways and is easy to come to a point of calling two methods that try to acquire the same lock.
- I added to the `threads.go` method comments if that function is or isn't thread-safe. Saying it differently, if you're calling a `threads.go` a method that in your call stack hasn't already acquired the thread-lock, then you can't use it. (Or we should do what I did here too, i.e: creating a `PutRecord` method that acquires the lock and calls `putRecord` which isn't thread-safe). This allows calling the action of saving a record from two different call-stack assumptions. (Hope not to confuse too much, lots of words here).

The concurrency granularity could be also at the log-level, but I think that would make things more complex than necessary without having proof that is really necessary.

These changes make the folder-sync app run on 4 or 5 peers setup each creating 3 o 4 random files, and reaching store convergence in ~10s. This is a quite crazy scenario of having so many joins and syncs of things in such a small time. Also, it seems that something of this fixed that problem that even with large sync timeouts, some peers didn't discover others.
When this get merged, you can play a bit more with different setups and see results.

I'll add comments to help understand the changes, and some bug-gems.