### PR TITLE
store: support fine-grained store changes notifications

### DIFF
--- a/api/service.go
+++ b/api/service.go
@@ -311,14 +311,17 @@ func (s *service) Listen(req *pb.ListenRequest, server pb.API_ListenServer) erro
 		return status.Error(codes.NotFound, "model not found")
 	}
 
-	listener := store.StateChangeListen()
-	defer listener.Discard()
+	l, err := store.Listen()
+	if err != nil {
+		return err
+	}
+	defer l.Close()
 
 	for {
 		select {
 		case _ = <-server.Context().Done():
 			return nil
-		case _, ok := <-listener.Channel():
+		case _, ok := <-l.Channel():
 			if !ok {
 				return nil
 			}

--- a/api/service.go
+++ b/api/service.go
@@ -311,7 +311,7 @@ func (s *service) Listen(req *pb.ListenRequest, server pb.API_ListenServer) erro
 		return status.Error(codes.NotFound, "model not found")
 	}
 
-	l, err := store.Listen()
+	l, err := store.Listen(es.ListenOption{Model: req.ModelName, ID: core.EntityID(req.EntityID)})
 	if err != nil {
 		return err
 	}

--- a/eventstore/listeners.go
+++ b/eventstore/listeners.go
@@ -1,0 +1,218 @@
+package eventstore
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/textileio/go-textile-core/broadcast"
+	core "github.com/textileio/go-textile-core/store"
+)
+
+// Listen returns a StoreListener which notifies about actions applying the
+// defined filters. The Store *won't* wait for slow receivers, so if the
+// channel is full, the action will be dropped.
+func (s *Store) Listen(los ...ListenOption) (StoreListener, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.closed {
+		return nil, fmt.Errorf("can't listen on closed Store")
+	}
+
+	sl := &storeListener{
+		scn:     s.stateChangedNotifee,
+		filters: los,
+		c:       make(chan Action, 1),
+	}
+	s.stateChangedNotifee.addListener(sl)
+	return sl, nil
+}
+
+// localEventListen returns a listener which notifies *locally generated*
+// events in models of the store. Caller should call .Discard() when
+// done.
+func (s *Store) localEventListen() *LocalEventListener {
+	return s.localEventsBus.Listen()
+}
+
+func (s *Store) notifyStateChanged(actions []Action) {
+	s.stateChangedNotifee.notify(actions)
+}
+
+func (s *Store) broadcastLocalEvent(e core.Event) error {
+	return s.localEventsBus.bus.SendWithTimeout(e, busTimeout)
+}
+
+type ActionType int
+type ListenActionType int
+
+const (
+	ActionCreate ActionType = iota + 1
+	ActionSave
+	ActionDelete
+)
+
+const (
+	ListenAll ListenActionType = iota
+	ListenCreate
+	ListenSave
+	ListenDelete
+)
+
+type Action struct {
+	Model string
+	Type  ActionType
+	ID    core.EntityID
+}
+
+type ListenOption struct {
+	Type  ListenActionType
+	Model string
+	ID    core.EntityID
+}
+
+type StoreListener interface {
+	Channel() <-chan Action
+	Close()
+}
+
+type stateChangedNotifee struct {
+	lock      sync.Mutex
+	listeners []*storeListener
+}
+
+type storeListener struct {
+	scn     *stateChangedNotifee
+	filters []ListenOption
+	c       chan Action
+}
+
+var _ StoreListener = (*storeListener)(nil)
+
+func (scn *stateChangedNotifee) notify(actions []Action) {
+	for _, a := range actions {
+		for _, l := range scn.listeners {
+			if l.evaluate(a) {
+				select {
+				case l.c <- a:
+				default:
+					log.Warningf("dropped action %v for reducer with filters %v", a, l.filters)
+				}
+			}
+		}
+	}
+}
+
+func (scn *stateChangedNotifee) addListener(sl *storeListener) {
+	scn.lock.Lock()
+	defer scn.lock.Unlock()
+	scn.listeners = append(scn.listeners, sl)
+}
+
+func (scn *stateChangedNotifee) remove(sl *storeListener) bool {
+	scn.lock.Lock()
+	defer scn.lock.Unlock()
+	for i := range scn.listeners {
+		if scn.listeners[i] == sl {
+			scn.listeners[i] = scn.listeners[len(scn.listeners)-1]
+			scn.listeners[len(scn.listeners)-1] = nil
+			scn.listeners = scn.listeners[:len(scn.listeners)-1]
+			return true
+		}
+	}
+	return false
+}
+
+func (scn *stateChangedNotifee) close() {
+	scn.lock.Lock()
+	defer scn.lock.Unlock()
+	for i := range scn.listeners {
+		close(scn.listeners[i].c)
+	}
+}
+
+// Channel returns an unbuffered channel to receive
+// store change notifications
+func (sl *storeListener) Channel() <-chan Action {
+	return sl.c
+}
+
+// Close indicates that no further notifications will be received
+// and ready for being garbage collected
+func (sl *storeListener) Close() {
+	if ok := sl.scn.remove(sl); ok {
+		close(sl.c)
+	}
+}
+
+func (sl *storeListener) evaluate(a Action) bool {
+	if len(sl.filters) == 0 {
+		return true
+	}
+	for _, f := range sl.filters {
+		switch f.Type {
+		case ListenAll:
+		case ListenCreate:
+			if a.Type != ActionCreate {
+				continue
+			}
+		case ListenSave:
+			if a.Type != ActionSave {
+				continue
+			}
+		case ListenDelete:
+			if a.Type != ActionDelete {
+				continue
+			}
+		default:
+			panic("unknown action type")
+		}
+
+		if f.Model != "" && f.Model != a.Model {
+			continue
+		}
+
+		if f.ID != core.EmptyEntityID && f.ID != a.ID {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+type localEventsBus struct {
+	bus *broadcast.Broadcaster
+}
+
+func (br *localEventsBus) Listen() *LocalEventListener {
+	l := &LocalEventListener{
+		listener: br.bus.Listen(),
+		c:        make(chan core.Event),
+	}
+
+	go func() {
+		for v := range l.listener.Channel() {
+			event := v.(core.Event)
+			l.c <- event
+		}
+		close(l.c)
+	}()
+
+	return l
+}
+
+// LocalEventListener notifies about store-local generated Events
+type LocalEventListener struct {
+	listener *broadcast.Listener
+	c        chan core.Event
+}
+
+// Channel returns an unbuffered channel to receive local events
+func (l *LocalEventListener) Channel() <-chan core.Event {
+	return l.c
+}
+
+// Discard indicates that no further events will be received
+// and ready for being garbage collected
+func (l *LocalEventListener) Discard() {
+	l.listener.Discard()
+}

--- a/eventstore/store.go
+++ b/eventstore/store.go
@@ -63,8 +63,8 @@ type Store struct {
 	jsonMode   bool
 	closed     bool
 
-	localEventsBus *localEventsBus
-	stateChanged   *stateChangedNotifee
+	localEventsBus      *localEventsBus
+	stateChangedNotifee *stateChangedNotifee
 }
 
 // NewStore creates a new Store, which will *own* ds and dispatcher for internal use.
@@ -102,16 +102,16 @@ func newStore(ts threadservice.Threadservice, config *StoreConfig) (*Store, erro
 
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &Store{
-		ctx:            ctx,
-		cancel:         cancel,
-		datastore:      config.Datastore,
-		dispatcher:     newDispatcher(config.Datastore),
-		eventcodec:     config.EventCodec,
-		modelNames:     make(map[string]*Model),
-		jsonMode:       config.JsonMode,
-		localEventsBus: &localEventsBus{bus: broadcast.NewBroadcaster(0)},
-		stateChanged:   &stateChangedNotifee{bus: broadcast.NewBroadcaster(1)},
-		threadservice:  ts,
+		ctx:                 ctx,
+		cancel:              cancel,
+		datastore:           config.Datastore,
+		dispatcher:          newDispatcher(config.Datastore),
+		eventcodec:          config.EventCodec,
+		modelNames:          make(map[string]*Model),
+		jsonMode:            config.JsonMode,
+		localEventsBus:      &localEventsBus{bus: broadcast.NewBroadcaster(0)},
+		stateChangedNotifee: &stateChangedNotifee{},
+		threadservice:       ts,
 	}
 
 	if s.jsonMode {
@@ -256,25 +256,12 @@ func (s *Store) GetModel(name string) *Model {
 	return s.modelNames[name]
 }
 
-// StateChangeListen returns a listener which notifies when store state
-// changed; some model reduced a new event.
-func (s *Store) StateChangeListen() *StateChangeListener {
-	return s.stateChanged.Listen()
-}
-
 // dispatch applies external events to the store. This function guarantee
 // no interference with registered model states, and viceversa.
 func (s *Store) dispatch(e core.Event) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	return s.dispatcher.Dispatch(e)
-}
-
-// localEventListen returns a listener which notifies *locally generated*
-// events in models of the store. Caller should call .Discard() when
-// done.
-func (s *Store) localEventListen() *LocalEventListener {
-	return s.localEventsBus.Listen()
 }
 
 // eventFromBytes generates an Event from its binary representation using
@@ -309,10 +296,10 @@ func (s *Store) Close() {
 	}
 	s.cancel()
 	s.localEventsBus.bus.Discard()
-	s.stateChanged.bus.Discard()
 	if !managedDatastore(s.datastore) {
 		_ = s.datastore.Close()
 	}
+	s.stateChangedNotifee.close()
 }
 
 // managedDatastore returns whether or not the datastore is
@@ -320,14 +307,6 @@ func (s *Store) Close() {
 func managedDatastore(ds ds.Datastore) bool {
 	_, ok := ds.(kt.KeyTransform)
 	return ok
-}
-
-func (s *Store) notifyStateChanged() error {
-	return s.stateChanged.bus.SendWithTimeout(struct{}{}, 0)
-}
-
-func (s *Store) broadcastLocalEvent(e core.Event) error {
-	return s.localEventsBus.bus.SendWithTimeout(e, busTimeout)
 }
 
 func (s *Store) writeTxn(m *Model, f func(txn *Txn) error) error {
@@ -348,81 +327,4 @@ func isValidModel(t interface{}) bool {
 		v = reflect.New(reflect.TypeOf(v))
 	}
 	return v.Elem().FieldByName(idFieldName).IsValid()
-}
-
-type localEventsBus struct {
-	bus *broadcast.Broadcaster
-}
-
-func (br *localEventsBus) Listen() *LocalEventListener {
-	l := &LocalEventListener{
-		listener: br.bus.Listen(),
-		c:        make(chan core.Event),
-	}
-
-	go func() {
-		for v := range l.listener.Channel() {
-			event := v.(core.Event)
-			l.c <- event
-		}
-		close(l.c)
-	}()
-
-	return l
-}
-
-// LocalEventListener notifies about store-local generated Events
-type LocalEventListener struct {
-	listener *broadcast.Listener
-	c        chan core.Event
-}
-
-// Channel returns an unbuffered channel to receive local events
-func (l *LocalEventListener) Channel() <-chan core.Event {
-	return l.c
-}
-
-// Discard indicates that no further events will be received
-// and ready for being garbage collected
-func (l *LocalEventListener) Discard() {
-	l.listener.Discard()
-}
-
-type stateChangedNotifee struct {
-	bus *broadcast.Broadcaster
-}
-
-func (scn *stateChangedNotifee) Listen() *StateChangeListener {
-	l := &StateChangeListener{
-		listener: scn.bus.Listen(),
-		c:        make(chan struct{}),
-	}
-
-	go func() {
-		for range l.listener.Channel() {
-
-			l.c <- struct{}{}
-		}
-		close(l.c)
-	}()
-
-	return l
-}
-
-// StateChangeListener notifies about store changed state
-type StateChangeListener struct {
-	listener *broadcast.Listener
-	c        chan struct{}
-}
-
-// Channel returns an unbuffered channel to receive
-// store change notifications
-func (scl *StateChangeListener) Channel() <-chan struct{} {
-	return scl.c
-}
-
-// Discard indicates that no further notifications will be received
-// and ready for being garbage collected
-func (scl *StateChangeListener) Discard() {
-	scl.listener.Discard()
 }

--- a/eventstore/store_test.go
+++ b/eventstore/store_test.go
@@ -3,6 +3,7 @@ package eventstore
 import (
 	"io/ioutil"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
@@ -105,6 +106,204 @@ func TestOptions(t *testing.T) {
 	defer s.Close()
 }
 
+func TestListeners(t *testing.T) {
+	t.Parallel()
+
+	assertActions := func(actions, expected []Action) {
+		if len(actions) != len(expected) {
+			t.Fatalf("number of actions isn't correct, expected %d, got %d", len(expected), len(actions))
+		}
+		for i := range actions {
+			if !reflect.DeepEqual(actions[i], expected[i]) {
+				t.Fatalf("wrong action detect, expected %v, got %v", expected[i], actions[i])
+			}
+		}
+	}
+
+	t.Run("AllStoreEvents", func(t *testing.T) {
+		t.Parallel()
+		actions := runListenersComplexUseCase(t)
+		expected := []Action{
+			{Model: "Model1", Type: ActionSave, ID: "id-i1"},
+			{Model: "Model1", Type: ActionCreate, ID: "id-i2"},
+			{Model: "Model2", Type: ActionCreate, ID: "id-j1"},
+			{Model: "Model1", Type: ActionSave, ID: "id-i1"},
+			{Model: "Model1", Type: ActionSave, ID: "id-i2"},
+			{Model: "Model2", Type: ActionSave, ID: "id-j1"},
+			{Model: "Model1", Type: ActionDelete, ID: "id-i1"},
+			{Model: "Model2", Type: ActionDelete, ID: "id-j1"},
+			{Model: "Model1", Type: ActionDelete, ID: "id-i2"},
+		}
+		assertActions(actions, expected)
+	})
+	t.Run("AnyModel1Events", func(t *testing.T) {
+		t.Parallel()
+		actions := runListenersComplexUseCase(t, ListenOption{Model: "Model1"})
+		expected := []Action{
+			{Model: "Model1", Type: ActionSave, ID: "id-i1"},
+			{Model: "Model1", Type: ActionCreate, ID: "id-i2"},
+			{Model: "Model1", Type: ActionSave, ID: "id-i1"},
+			{Model: "Model1", Type: ActionSave, ID: "id-i2"},
+			{Model: "Model1", Type: ActionDelete, ID: "id-i1"},
+			{Model: "Model1", Type: ActionDelete, ID: "id-i2"},
+		}
+		assertActions(actions, expected)
+	})
+	t.Run("AnyModel2Events", func(t *testing.T) {
+		t.Parallel()
+		actions := runListenersComplexUseCase(t, ListenOption{Model: "Model2"})
+		expected := []Action{
+			{Model: "Model2", Type: ActionCreate, ID: "id-j1"},
+			{Model: "Model2", Type: ActionSave, ID: "id-j1"},
+			{Model: "Model2", Type: ActionDelete, ID: "id-j1"},
+		}
+		assertActions(actions, expected)
+	})
+	t.Run("AnyCreateEvent", func(t *testing.T) {
+		t.Parallel()
+		actions := runListenersComplexUseCase(t, ListenOption{Type: ListenCreate})
+		expected := []Action{
+			{Model: "Model1", Type: ActionCreate, ID: "id-i2"},
+			{Model: "Model2", Type: ActionCreate, ID: "id-j1"},
+		}
+		assertActions(actions, expected)
+	})
+	t.Run("AnySaveEvent", func(t *testing.T) {
+		t.Parallel()
+		actions := runListenersComplexUseCase(t, ListenOption{Type: ListenSave})
+		expected := []Action{
+			{Model: "Model1", Type: ActionSave, ID: "id-i1"},
+			{Model: "Model1", Type: ActionSave, ID: "id-i1"},
+			{Model: "Model1", Type: ActionSave, ID: "id-i2"},
+			{Model: "Model2", Type: ActionSave, ID: "id-j1"},
+		}
+		assertActions(actions, expected)
+	})
+	t.Run("AnyDeleteEvent", func(t *testing.T) {
+		t.Parallel()
+		actions := runListenersComplexUseCase(t, ListenOption{Type: ListenDelete})
+		expected := []Action{
+			{Model: "Model1", Type: ActionDelete, ID: "id-i1"},
+			{Model: "Model2", Type: ActionDelete, ID: "id-j1"},
+			{Model: "Model1", Type: ActionDelete, ID: "id-i2"},
+		}
+		assertActions(actions, expected)
+	})
+	t.Run("AnyModel1OrDeleteModel2Events", func(t *testing.T) {
+		t.Parallel()
+		actions := runListenersComplexUseCase(t, ListenOption{Model: "Model1"}, ListenOption{Model: "Model2", Type: ListenDelete})
+		expected := []Action{
+			{Model: "Model1", Type: ActionSave, ID: "id-i1"},
+			{Model: "Model1", Type: ActionCreate, ID: "id-i2"},
+			{Model: "Model1", Type: ActionSave, ID: "id-i1"},
+			{Model: "Model1", Type: ActionSave, ID: "id-i2"},
+			{Model: "Model1", Type: ActionDelete, ID: "id-i1"},
+			{Model: "Model2", Type: ActionDelete, ID: "id-j1"},
+			{Model: "Model1", Type: ActionDelete, ID: "id-i2"},
+		}
+		assertActions(actions, expected)
+	})
+	t.Run("EmptyFilterEvent", func(t *testing.T) {
+		t.Parallel()
+		actions := runListenersComplexUseCase(t, ListenOption{Model: "Model3"})
+		expected := []Action{}
+		assertActions(actions, expected)
+	})
+	t.Run("MixedComplexEvent", func(t *testing.T) {
+		t.Parallel()
+		actions := runListenersComplexUseCase(t,
+			ListenOption{Model: "Model2", Type: ListenSave},
+			ListenOption{Model: "Model1", Type: ListenSave, ID: "id-i2"},
+			ListenOption{Model: "Model1", Type: ListenDelete, ID: "id-i1"},
+			ListenOption{Model: "Model2", Type: ListenDelete},
+		)
+		expected := []Action{
+			{Model: "Model1", Type: ActionSave, ID: "id-i2"},
+			{Model: "Model2", Type: ActionSave, ID: "id-j1"},
+			{Model: "Model1", Type: ActionDelete, ID: "id-i1"},
+			{Model: "Model2", Type: ActionDelete, ID: "id-j1"},
+		}
+		assertActions(actions, expected)
+	})
+}
+
+// runListenersComplexUseCase runs a complex store use-case, and returns
+// Actions received with the ...ListenOption provided.
+func runListenersComplexUseCase(t *testing.T, los ...ListenOption) []Action {
+	t.Helper()
+	s, close := createTestStore(t)
+	m1, err := s.Register("Model1", &dummyModel{})
+	checkErr(t, err)
+	m2, err := s.Register("Model2", &dummyModel{})
+	checkErr(t, err)
+
+	// Create some instance *before* any listener, just to test doesn't appear
+	// on listener Action stream.
+	i1 := &dummyModel{ID: "id-i1", Name: "Textile1"}
+	checkErr(t, m1.Create(i1))
+
+	l, err := s.Listen(los...)
+	checkErr(t, err)
+	var actions []Action
+	go func() {
+		for a := range l.Channel() {
+			actions = append(actions, a)
+		}
+	}()
+
+	// Model1 Save i1
+	i1.Name = "Textile0"
+	checkErr(t, m1.Save(i1))
+
+	// Model1 Create i2
+	i2 := &dummyModel{ID: "id-i2", Name: "Textile2"}
+	checkErr(t, m1.Create(i2))
+
+	// Model2 Create j1
+	j1 := &dummyModel{ID: "id-j1", Name: "Textile3"}
+	checkErr(t, m2.Create(j1))
+
+	// Model1 Save i1
+	// Model1 Save i2
+	err = m1.WriteTxn(func(txn *Txn) error {
+		i1.Counter = 30
+		i2.Counter = 11
+		if err := txn.Save(i1, i2); err != nil {
+			return nil
+		}
+		return nil
+	})
+	checkErr(t, err)
+
+	// Model2 Save j1
+	j1.Counter = -1
+	j1.Name = "Textile33"
+	checkErr(t, m2.Save(j1))
+
+	checkErr(t, m1.Delete(i1.ID))
+
+	// Model2 Delete
+	checkErr(t, m2.Delete(j1.ID))
+
+	// Model2 Delete i2
+	checkErr(t, m1.Delete(i2.ID))
+
+	l.Close()
+	close()
+	// Expected generated actions:
+	// Model1 Save i1
+	// Model1 Create i2
+	// Model2 Create j1
+	// Save i1
+	// Save i2
+	// Model2 Save j1
+	// Delete i1
+	// Model2 Delete j1
+	// Delete i2
+
+	return actions
+}
+
 type dummyModel struct {
 	ID      core.EntityID
 	Name    string
@@ -117,9 +316,9 @@ type mockEventCodec struct {
 
 var _ core.EventCodec = (*mockEventCodec)(nil)
 
-func (dec *mockEventCodec) Reduce(e core.Event, datastore ds.Datastore, baseKey ds.Key) error {
+func (dec *mockEventCodec) Reduce(e core.Event, datastore ds.Datastore, baseKey ds.Key) ([]core.ReduceAction, error) {
 	dec.called = true
-	return nil
+	return nil, nil
 }
 func (dec *mockEventCodec) Create(ops []core.Action) ([]core.Event, error) {
 	dec.called = true

--- a/examples/e2e_counter/reader.go
+++ b/examples/e2e_counter/reader.go
@@ -25,7 +25,8 @@ func runReaderPeer(repo string, port int) {
 	m, err := store.Register("counter", &myCounter{})
 	checkErr(err)
 
-	l := store.StateChangeListen()
+	l, err := store.Listen()
+	checkErr(err)
 	checkErr(store.StartFromAddr(writerAddr, fkey, rkey))
 	for range l.Channel() {
 		err := m.ReadTxn(func(txn *es.Txn) error {

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/multiformats/go-multihash v0.0.8
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/rs/cors v1.7.0 // indirect
-	github.com/textileio/go-textile-core v0.0.0-20191119181245-af71494bbb10
+	github.com/textileio/go-textile-core v0.0.0-20191205110409-5785e1750a85
 	github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc
 	github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
@@ -52,5 +52,3 @@ require (
 	google.golang.org/grpc v1.24.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
-
-replace github.com/textileio/go-textile-core v0.0.0-20191119181245-af71494bbb10 => ../go-textile-core

--- a/go.mod
+++ b/go.mod
@@ -47,11 +47,10 @@ require (
 	github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0
-	golang.org/x/crypto v0.0.0-20190926180335-cea2066c6411 // indirect
 	golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
-	golang.org/x/sys v0.0.0-20190926180325-855e68c8590b // indirect
-	google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873 // indirect
 	google.golang.org/grpc v1.24.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
+
+replace github.com/textileio/go-textile-core v0.0.0-20191119181245-af71494bbb10 => ../go-textile-core

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,7 @@ github.com/davidlazar/go-crypto v0.0.0-20170701192655-dcfb0a7ac018/go.mod h1:rQY
 github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f/go.mod h1:VZxzAIRPHRVNRKRo6AXrX9BJegn6il06VMTZVJYCIjQ=
 github.com/dgraph-io/badger v1.6.0-rc1 h1:JphPpoBZJ3WHha133BGYlQqltSGIhV+VsEID0++nN9A=
 github.com/dgraph-io/badger v1.6.0-rc1/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
@@ -475,8 +476,6 @@ github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709 h1:Ko2LQMrRU+Oy
 github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
-github.com/textileio/go-textile-core v0.0.0-20191119181245-af71494bbb10 h1:foK4CiQjgtmTEtKbUSlx4xbiadjAuQYOQj/3THNEP6k=
-github.com/textileio/go-textile-core v0.0.0-20191119181245-af71494bbb10/go.mod h1:k4D4ifgEMPykRuguG3m9Ir4BEeh01itnFJSkCy9QyyY=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436 h1:qOpVTI+BrstcjTZLm2Yz/3sOnqkzj3FQoh0g+E5s3Gc=
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
@@ -603,8 +602,6 @@ google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmE
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1 h1:Hz2g2wirWK7H0qIIhGIqRGTuMwTE8HEKFnDZZ7lm9NU=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
-google.golang.org/grpc v1.21.1 h1:j6XxA85m/6txkUCHvzlV5f+HBNl/1r5cZ2A/3IEFOO8=
-google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.24.0 h1:vb/1TCsVn3DcJlQ0Gs1yB1pKI6Do2/QNwxdKqmc/b0s=
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -476,6 +476,8 @@ github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709 h1:Ko2LQMrRU+Oy
 github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
+github.com/textileio/go-textile-core v0.0.0-20191205110409-5785e1750a85 h1:gnvpZErFp+ivAPQsXbRsqRLZA0PxPGs2cR7v6iVSLI8=
+github.com/textileio/go-textile-core v0.0.0-20191205110409-5785e1750a85/go.mod h1:zZIyxcCQ8EDdOJmv3goBIYs5nsCG/DPhNdWTEvToDWA=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436 h1:qOpVTI+BrstcjTZLm2Yz/3sOnqkzj3FQoh0g+E5s3Gc=
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=


### PR DESCRIPTION
Fixes #134 

This PR adds support for a new way of listening changes in `Store`. The old way that simply returned a `chan struct{}` (and good luck!) is gone.

I migrated all uses of old API to the new one that is more general.

Main idea:
The `Store` has a `Listen(..)` API. 
This API receives whatever the number of optional filters to configure what changes you want to hear in flexible ways.
Examples:
- Listen to all changes: `l, err := store.Listen()` (call without args)
- Listen to all changes of some model: `l, err := store.Listen(ListenOption{Model: "Person"})`
- More complex example: listen to Saves in Model2 *or* Saves in Model1 with EntityID "id-i2" *or* deletes of Model1 with id-i1 *or* all deletes from Model2:
```
opts := []ListenOption{ 
			ListenOption{Model: "Model2", Type: ListenSave},
			ListenOption{Model: "Model1", Type: ListenSave, ID: "id-i2"},
			ListenOption{Model: "Model1", Type: ListenDelete, ID: "id-i1"},
			ListenOption{Model: "Model2", Type: ListenDelete},
}
l, err := store.Listen(opts...)
```

As you can see, you can concatenate filters with `Model`, `Type`, `ID` (any of them optional), to allow most possible combinations of wanted things. e.g: if you don't specify a `Type` for the `ListenOption` would mean all types (save, delete, create))

That's for the "filtering" part.

This `l` returned, has `l.Channel()`, which is: `chan Action`:
```
type Action struct {
	Model string
	Type  ActionType
	ID    core.EntityID
}
```
Saying it differently, now what's received in the channel isn't a `struct{}`, is an `Action` (filtered by whatever you chose) describing what exactly changed in Store: in which model, which entityID, what happened (Create, Save, or Delete).

See the new tests to get an extra feeling of how should work.

Depends on [merging a PR from `go-textile-core`](https://github.com/textileio/go-textile-core/pull/32 ) which is ready for _review_. After merged, I'll change the `go.mod` of this PR and will be ready for official review (CirceCI tests will pass when this is done).

Added some comments to help review; ask anything if isn't clear enough!