### PR TITLE
JSONQuery tests use fluent API

### DIFF
--- a/api/service.go
+++ b/api/service.go
@@ -404,12 +404,12 @@ func (s *service) processFindByIDRequest(req *pb.ModelFindByIDRequest, findFunc 
 	return &pb.ModelFindByIDReply{Entity: result}, nil
 }
 
-func (s *service) processFindRequest(req *pb.ModelFindRequest, findFunc func(q es.JSONQuery) (ret []string, err error)) (*pb.ModelFindReply, error) {
+func (s *service) processFindRequest(req *pb.ModelFindRequest, findFunc func(q *es.JSONQuery) (ret []string, err error)) (*pb.ModelFindReply, error) {
 	q := &es.JSONQuery{}
 	if err := json.Unmarshal(req.GetQueryJSON(), q); err != nil {
 		return nil, err
 	}
-	stringEntities, err := findFunc(*q)
+	stringEntities, err := findFunc(q)
 	if err != nil {
 		return nil, err
 	}

--- a/eventstore/model.go
+++ b/eventstore/model.go
@@ -124,7 +124,7 @@ func (m *Model) Find(result interface{}, q *Query) error {
 }
 
 // FindJSON executes a Query in in JSONMode and returns the result.
-func (m *Model) FindJSON(q JSONQuery) (ret []string, err error) {
+func (m *Model) FindJSON(q *JSONQuery) (ret []string, err error) {
 	m.ReadTxn(func(txn *Txn) error {
 		ret, err = txn.FindJSON(q)
 		return err
@@ -135,8 +135,8 @@ func (m *Model) FindJSON(q JSONQuery) (ret []string, err error) {
 func (m *Model) validInstance(v interface{}) (bool, error) {
 	var vLoader gojsonschema.JSONLoader
 	if m.store.jsonMode {
-		strJson := v.(*string)
-		vLoader = gojsonschema.NewBytesLoader([]byte(*strJson))
+		strJSON := v.(*string)
+		vLoader = gojsonschema.NewBytesLoader([]byte(*strJSON))
 	} else {
 		vLoader = gojsonschema.NewGoLoader(v)
 	}

--- a/eventstore/query.go
+++ b/eventstore/query.go
@@ -36,6 +36,22 @@ func Where(field string) *Criterion {
 	}
 }
 
+// OrderBy specify ascending order for the query results.
+func OrderBy(field string) *Query {
+	q := &Query{}
+	q.sort.fieldPath = field
+	q.sort.desc = false
+	return q
+}
+
+// OrderByDesc specify descending order for the query results.
+func OrderByDesc(field string) *Query {
+	q := &Query{}
+	q.sort.fieldPath = field
+	q.sort.desc = true
+	return q
+}
+
 // And concatenates a new condition in an existing field.
 func (q *Query) And(field string) *Criterion {
 	return &Criterion{

--- a/eventstore/query_json.go
+++ b/eventstore/query_json.go
@@ -161,6 +161,18 @@ func createValue(value interface{}) JSONValue {
 	if ok {
 		return JSONValue{Float: &f}
 	}
+	sp, ok := value.(*string)
+	if ok {
+		return JSONValue{String: sp}
+	}
+	bp, ok := value.(*bool)
+	if ok {
+		return JSONValue{Bool: bp}
+	}
+	fp, ok := value.(*float64)
+	if ok {
+		return JSONValue{Float: fp}
+	}
 	return JSONValue{}
 }
 

--- a/eventstore/query_json.go
+++ b/eventstore/query_json.go
@@ -68,6 +68,22 @@ func JSONWhere(field string) *JSONCriterion {
 	}
 }
 
+// JSONOrderBy specify ascending order for the query results.
+func JSONOrderBy(field string) *JSONQuery {
+	q := &JSONQuery{}
+	q.Sort.FieldPath = field
+	q.Sort.Desc = false
+	return q
+}
+
+// JSONOrderByDesc specify descending order for the query results.
+func JSONOrderByDesc(field string) *JSONQuery {
+	q := &JSONQuery{}
+	q.Sort.FieldPath = field
+	q.Sort.Desc = true
+	return q
+}
+
 // JSONAnd concatenates a new condition in an existing field.
 func (q *JSONQuery) JSONAnd(field string) *JSONCriterion {
 	return &JSONCriterion{
@@ -159,7 +175,7 @@ func (c *JSONCriterion) createcriterion(op JSONOperation, value interface{}) *JS
 }
 
 // FindJSON queries for entities by JSONQuery
-func (t *Txn) FindJSON(q JSONQuery) ([]string, error) {
+func (t *Txn) FindJSON(q *JSONQuery) ([]string, error) {
 	dsq := dsquery.Query{
 		Prefix: baseKey.ChildString(t.model.name).String(),
 	}

--- a/eventstore/query_jsonmode_test.go
+++ b/eventstore/query_jsonmode_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	testQueryJsonModeSchema = `{
+	testQueryJSONModeSchema = `{
 		"$schema": "http://json-schema.org/draft-04/schema#",
 		"$ref": "#/definitions/book",
 		"definitions": {
@@ -61,7 +61,7 @@ const (
 
 type jsonQueryTest struct {
 	name    string
-	query   JSONQuery
+	query   *JSONQuery
 	resIdx  []int
 	ordered bool
 }
@@ -96,553 +96,200 @@ var (
 		jsonQueryTest{
 			name:   "EqByTitle1",
 			resIdx: []int{0},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Title",
-						Operation: Eq,
-						Value: JSONValue{
-							String: &title0,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Title").Eq(&title0),
 		},
 		jsonQueryTest{
 			name:   "NeByTitle1",
 			resIdx: []int{1, 2, 3},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Title",
-						Operation: Ne,
-						Value: JSONValue{
-							String: &title0,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Title").Ne(&title0),
 		},
 		jsonQueryTest{
 			name:   "NeByTitle",
 			resIdx: []int{0, 1, 2, 3},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Title",
-						Operation: Ne,
-						Value: JSONValue{
-							String: &title,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Title").Ne(&title),
 		},
 		jsonQueryTest{
 			name:   "EqByTitle",
 			resIdx: []int{},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Title",
-						Operation: Eq,
-						Value: JSONValue{
-							String: &title,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Title").Eq(&title),
 		},
 		jsonQueryTest{
 			name:   "LtByTitle",
 			resIdx: []int{},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Title",
-						Operation: Lt,
-						Value: JSONValue{
-							String: &title,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Title").Lt(&title),
 		},
 		jsonQueryTest{
 			name:   "GtByTitle",
 			resIdx: []int{0, 1, 2, 3},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Title",
-						Operation: Gt,
-						Value: JSONValue{
-							String: &title,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Title").Gt(&title),
 		},
 		jsonQueryTest{
 			name:   "GtByTitleMax",
 			resIdx: []int{},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Title",
-						Operation: Gt,
-						Value: JSONValue{
-							String: &titleMax,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Title").Gt(&titleMax),
 		},
 
 		// Ands "int" (which query interpret as float)
 		jsonQueryTest{
 			name:   "EqByTotalReads1",
 			resIdx: []int{0},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Meta.TotalReads",
-						Operation: Eq,
-						Value: JSONValue{
-							Float: &totreadEq1,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Meta.TotalReads").Eq(&totreadEq1),
 		},
 		jsonQueryTest{
 			name:   "LtByTotalReads1",
 			resIdx: []int{},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Meta.TotalReads",
-						Operation: Lt,
-						Value: JSONValue{
-							Float: &totreadEq1,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Meta.TotalReads").Lt(&totreadEq1),
 		},
 		jsonQueryTest{
 			name:   "LeByTotalReadsBigger",
 			resIdx: []int{0, 1, 2, 3},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Meta.TotalReads",
-						Operation: Le,
-						Value: JSONValue{
-							Float: &totreadMax,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Meta.TotalReads").Le(&totreadMax),
 		},
 		jsonQueryTest{
 			name:   "GeByTotalReadsMin",
 			resIdx: []int{0, 1, 2, 3},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Meta.TotalReads",
-						Operation: Ge,
-						Value: JSONValue{
-							Float: &totreadMin,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Meta.TotalReads").Ge(&totreadMin),
 		},
 		jsonQueryTest{
 			name:   "LtByTotalReadsMidpoint",
 			resIdx: []int{0, 2},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Meta.TotalReads",
-						Operation: Lt,
-						Value: JSONValue{
-							Float: &totreadMid,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Meta.TotalReads").Lt(&totreadMid),
 		},
 		jsonQueryTest{
 			name:   "GtByTotalReadsMidpoint",
 			resIdx: []int{1, 3},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Meta.TotalReads",
-						Operation: Gt,
-						Value: JSONValue{
-							Float: &totreadMid,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Meta.TotalReads").Gt(&totreadMid),
 		},
 		jsonQueryTest{
 			name:   "LtByTotalReads2",
 			resIdx: []int{0, 2},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Meta.TotalReads",
-						Operation: Lt,
-						Value: JSONValue{
-							Float: &totreadEq2,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Meta.TotalReads").Lt(&totreadEq2),
 		},
 
 		// Ands float
 		jsonQueryTest{
 			name:   "EqByRating1",
 			resIdx: []int{0},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Meta.Rating",
-						Operation: Eq,
-						Value: JSONValue{
-							Float: &rating1,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Meta.Rating").Eq(&rating1),
 		},
 		jsonQueryTest{
 			name:   "GtByRating1",
 			resIdx: []int{1, 2},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Meta.Rating",
-						Operation: Gt,
-						Value: JSONValue{
-							Float: &rating1,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Meta.Rating").Gt(&rating1),
 		},
 		jsonQueryTest{
 			name:   "LeByRatingMin",
 			resIdx: []int{},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Meta.Rating",
-						Operation: Le,
-						Value: JSONValue{
-							Float: &ratingMin,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Meta.Rating").Le(&ratingMin),
 		},
 		jsonQueryTest{
 			name:   "GeByRatingMin",
 			resIdx: []int{0, 1, 2, 3},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Meta.Rating",
-						Operation: Ge,
-						Value: JSONValue{
-							Float: &ratingMin,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Meta.Rating").Ge(&ratingMin),
 		},
 		jsonQueryTest{
 			name:   "LeByRatingMid",
 			resIdx: []int{0, 3},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Meta.Rating",
-						Operation: Le,
-						Value: JSONValue{
-							Float: &ratingMid,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Meta.Rating").Le(&ratingMid),
 		},
 		jsonQueryTest{
 			name:   "GeByRatingMid",
 			resIdx: []int{1, 2},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Meta.Rating",
-						Operation: Ge,
-						Value: JSONValue{
-							Float: &ratingMid,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Meta.Rating").Ge(&ratingMid),
 		},
 		jsonQueryTest{
 			name:   "LeByRatingMax",
 			resIdx: []int{0, 1, 2, 3},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Meta.Rating",
-						Operation: Le,
-						Value: JSONValue{
-							Float: &ratingMax,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Meta.Rating").Le(&ratingMax),
 		},
 		jsonQueryTest{
 			name:   "GtByRatingMax",
 			resIdx: []int{},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Meta.Rating",
-						Operation: Gt,
-						Value: JSONValue{
-							Float: &ratingMax,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Meta.Rating").Gt(&ratingMax),
 		},
 		// Ands bool
 		jsonQueryTest{
 			name:   "EqByBanned",
 			resIdx: []int{0, 3},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Banned",
-						Operation: Eq,
-						Value: JSONValue{
-							Bool: &boolTrue,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Banned").Eq(&boolTrue),
 		},
 		jsonQueryTest{
 			name:   "NeByBanned",
 			resIdx: []int{1, 2},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Banned",
-						Operation: Ne,
-						Value: JSONValue{
-							Bool: &boolTrue,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Banned").Ne(&boolTrue),
 		},
 		jsonQueryTest{
 			name:   "EqByBannedFalse",
 			resIdx: []int{1, 2},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Banned",
-						Operation: Eq,
-						Value: JSONValue{
-							Bool: &boolFalse,
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Banned").Eq(&boolFalse),
 		},
 
 		// Ors
 		jsonQueryTest{
 			name:   "EqTitle1OrTitle3",
 			resIdx: []int{0, 2},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Title",
-						Operation: Eq,
-						Value: JSONValue{
-							String: &title0,
-						},
-					},
-				},
-				Ors: []*JSONQuery{
-					&JSONQuery{
-						Ands: []*JSONCriterion{
-							&JSONCriterion{
-								FieldPath: "Title",
-								Operation: Eq,
-								Value: JSONValue{
-									String: &title3,
-								},
-							},
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Title").Eq(&title0).JSONOr(JSONWhere("Title").Eq(&title3)),
 		},
 		jsonQueryTest{
 			name:   "EqTitle2OrRating",
 			resIdx: []int{0, 1},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Title",
-						Operation: Eq,
-						Value: JSONValue{
-							String: &title1,
-						},
-					},
-				},
-				Ors: []*JSONQuery{
-					&JSONQuery{
-						Ands: []*JSONCriterion{
-							&JSONCriterion{
-								FieldPath: "Meta.Rating",
-								Operation: Eq,
-								Value: JSONValue{
-									Float: &rating1,
-								},
-							},
-						},
-					},
-				},
-			},
+			query:  JSONWhere("Title").Eq(&title1).JSONOr(JSONWhere("Meta.Rating").Eq(&rating1)),
 		},
 
 		// Ordering (string, int, float)
 		jsonQueryTest{
-			name:   "AllOrderedTitle",
-			resIdx: []int{0, 1, 2, 3},
-			query: JSONQuery{
-				Sort: JSONSort{
-					FieldPath: "Title",
-				},
-			},
+			name:    "AllOrderedTitle",
+			resIdx:  []int{0, 1, 2, 3},
+			query:   JSONOrderBy("Title"),
 			ordered: true,
 		},
 		jsonQueryTest{
-			name:   "AllOrderedTitleDesc",
-			resIdx: []int{3, 2, 1, 0},
-			query: JSONQuery{
-				Sort: JSONSort{
-					FieldPath: "Title",
-					Desc:      true,
-				},
-			},
+			name:    "AllOrderedTitleDesc",
+			resIdx:  []int{3, 2, 1, 0},
+			query:   JSONOrderByDesc("Title"),
 			ordered: true,
 		},
 		jsonQueryTest{
-			name:   "AllOrderedTotalReads",
-			resIdx: []int{0, 2, 1, 3},
-			query: JSONQuery{
-				Sort: JSONSort{
-					FieldPath: "Meta.TotalReads",
-					Desc:      false,
-				},
-			},
+			name:    "AllOrderedTotalReads",
+			resIdx:  []int{0, 2, 1, 3},
+			query:   JSONOrderBy("Meta.TotalReads"),
 			ordered: true,
 		},
 		jsonQueryTest{
-			name:   "AllOrderedTotalReads",
-			resIdx: []int{3, 1, 2, 0},
-			query: JSONQuery{
-				Sort: JSONSort{
-					FieldPath: "Meta.TotalReads",
-					Desc:      true,
-				},
-			},
+			name:    "AllOrderedTotalReads",
+			resIdx:  []int{3, 1, 2, 0},
+			query:   JSONOrderByDesc("Meta.TotalReads"),
 			ordered: true,
 		},
 		jsonQueryTest{
-			name:   "AllOrderedRatings",
-			resIdx: []int{3, 0, 1, 2},
-			query: JSONQuery{
-				Sort: JSONSort{
-					FieldPath: "Meta.Rating",
-					Desc:      false,
-				},
-			},
+			name:    "AllOrderedRatings",
+			resIdx:  []int{3, 0, 1, 2},
+			query:   JSONOrderBy("Meta.Rating"),
 			ordered: true,
 		},
 		jsonQueryTest{
-			name:   "AllOrderedRatingsDesc",
-			resIdx: []int{2, 1, 0, 3},
-			query: JSONQuery{
-				Sort: JSONSort{
-					FieldPath: "Meta.Rating",
-					Desc:      true,
-				},
-			},
+			name:    "AllOrderedRatingsDesc",
+			resIdx:  []int{2, 1, 0, 3},
+			query:   JSONOrderByDesc("Meta.Rating"),
 			ordered: true,
 		},
 		jsonQueryTest{
-			name:   "AllOrderedRatingsDescWithAnd",
-			resIdx: []int{2, 1},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Meta.Rating",
-						Operation: Gt,
-						Value: JSONValue{
-							Float: &ratingMid,
-						},
-					},
-				},
-				Sort: JSONSort{
-					FieldPath: "Meta.TotalReads",
-					Desc:      false,
-				},
-			},
+			name:    "AllOrderedRatingsDescWithAnd",
+			resIdx:  []int{2, 1},
+			query:   JSONWhere("Meta.Rating").Gt(&ratingMid).JSONOrderBy("Meta.TotalReads"),
 			ordered: true,
 		},
 		jsonQueryTest{
-			name:   "AllOrderedRatingsDescWithAndDesc",
-			resIdx: []int{1, 2},
-			query: JSONQuery{
-				Ands: []*JSONCriterion{
-					&JSONCriterion{
-						FieldPath: "Meta.Rating",
-						Operation: Gt,
-						Value: JSONValue{
-							Float: &ratingMid,
-						},
-					},
-				},
-				Sort: JSONSort{
-					FieldPath: "Meta.TotalReads",
-					Desc:      true,
-				},
-			},
+			name:    "AllOrderedRatingsDescWithAndDesc",
+			resIdx:  []int{1, 2},
+			query:   JSONWhere("Meta.Rating").Gt(&ratingMid).JSONOrderByDesc("Meta.TotalReads"),
 			ordered: true,
 		},
 	}
 )
 
 func TestQueryJsonMode(t *testing.T) {
-	m, clean := createModelWithJsonData(t)
+	m, clean := createModelWithJSONData(t)
 	defer clean()
 
 	for _, q := range jsonQueries {
@@ -675,9 +322,9 @@ func TestQueryJsonMode(t *testing.T) {
 	}
 }
 
-func createModelWithJsonData(t *testing.T) (*Model, func()) {
+func createModelWithJSONData(t *testing.T) (*Model, func()) {
 	s, clean := createTestStore(t, WithJsonMode(true))
-	m, err := s.RegisterSchema("Book", testQueryJsonModeSchema)
+	m, err := s.RegisterSchema("Book", testQueryJSONModeSchema)
 	checkErr(t, err)
 	for i := range jsonSampleData {
 		if err = m.Create(&jsonSampleData[i]); err != nil {

--- a/eventstore/query_test.go
+++ b/eventstore/query_test.go
@@ -92,6 +92,15 @@ var (
 
 		queryTest{name: "SortAscFloat", query: Where("Meta.TotalReads").Gt(10).OrderBy("Meta.Rating"), resIdx: []int{1, 2, 3, 4}, ordered: true},
 		queryTest{name: "SortDescFloat", query: Where("Meta.TotalReads").Gt(10).OrderByDesc("Meta.Rating"), resIdx: []int{4, 3, 2, 1}, ordered: true},
+
+		queryTest{name: "SortAllAscString", query: OrderBy("Title"), resIdx: []int{0, 1, 2, 3, 4}, ordered: true},
+		queryTest{name: "SortAllDescString", query: OrderByDesc("Title"), resIdx: []int{4, 3, 2, 1, 0}, ordered: true},
+
+		queryTest{name: "SortAllAscInt", query: OrderBy("Meta.TotalReads"), resIdx: []int{0, 1, 2, 3, 4}, ordered: true},
+		queryTest{name: "SortAllDescInt", query: OrderByDesc("Meta.TotalReads"), resIdx: []int{4, 3, 2, 1, 0}, ordered: true},
+
+		queryTest{name: "SortAllAscFloat", query: OrderBy("Meta.Rating"), resIdx: []int{0, 1, 2, 3, 4}, ordered: true},
+		queryTest{name: "SortAllDescFloat", query: OrderByDesc("Meta.Rating"), resIdx: []int{4, 3, 2, 1, 0}, ordered: true},
 	}
 )
 


### PR DESCRIPTION
Also added top level `OrderBy` and `OrderByDesc` query creator methods to non-json queries.