### PR TITLE
chore: always use multiaddr

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -250,8 +250,8 @@ func (c *Client) Listen(storeID, modelName, entityID string) (<-chan ListenEvent
 		for {
 			event, err := stream.Recv()
 			if err != nil {
-				status := status.Convert(err)
-				if status == nil || (status != nil && status.Code() != codes.Canceled) {
+				stat := status.Convert(err)
+				if stat == nil || (stat.Code() != codes.Canceled) {
 					channel <- ListenEvent{err: err}
 				}
 				break

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	ma "github.com/multiformats/go-multiaddr"
 	"github.com/textileio/go-textile-threads/api"
 	es "github.com/textileio/go-textile-threads/eventstore"
 	"github.com/textileio/go-textile-threads/util"
@@ -447,10 +448,12 @@ func makeServer() (*api.Server, func()) {
 	if err != nil {
 		panic(err)
 	}
+	hostAddr, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/4106")
+	hostProxyAddr, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/5150")
 	ts, err := es.DefaultThreadservice(
 		dir,
-		es.ListenPort(4106),
-		es.ProxyPort(5150),
+		es.HostAddr(hostAddr),
+		es.HostProxyAddr(hostProxyAddr),
 		es.Debug(true))
 	if err != nil {
 		panic(err)

--- a/eventstore/manager_test.go
+++ b/eventstore/manager_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	ma "github.com/multiformats/go-multiaddr"
 )
 
 var (
@@ -61,7 +63,9 @@ func TestManager_GetStore(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "")
 	checkErr(t, err)
-	ts, err := DefaultThreadservice(dir, ProxyPort(0))
+	addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
+	checkErr(t, err)
+	ts, err := DefaultThreadservice(dir, HostProxyAddr(addr))
 	checkErr(t, err)
 	man, err := NewManager(ts, WithRepoPath(dir), WithJsonMode(true), WithDebug(true))
 	checkErr(t, err)
@@ -94,7 +98,9 @@ func TestManager_GetStore(t *testing.T) {
 	checkErr(t, err)
 
 	t.Run("GetHydrated", func(t *testing.T) {
-		ts, err := DefaultThreadservice(dir, ProxyPort(0))
+		addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
+		checkErr(t, err)
+		ts, err := DefaultThreadservice(dir, HostProxyAddr(addr))
 		checkErr(t, err)
 		man, err := NewManager(ts, WithRepoPath(dir), WithJsonMode(true), WithDebug(true))
 		checkErr(t, err)
@@ -126,7 +132,9 @@ func TestManager_GetStore(t *testing.T) {
 func createTestManager(t *testing.T) (*Manager, func()) {
 	dir, err := ioutil.TempDir("", "")
 	checkErr(t, err)
-	ts, err := DefaultThreadservice(dir, ProxyPort(0))
+	addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
+	checkErr(t, err)
+	ts, err := DefaultThreadservice(dir, HostProxyAddr(addr))
 	checkErr(t, err)
 	m, err := NewManager(ts, WithRepoPath(dir), WithJsonMode(true), WithDebug(true))
 	checkErr(t, err)

--- a/eventstore/manager_test.go
+++ b/eventstore/manager_test.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"testing"
 	"time"
-
-	ma "github.com/multiformats/go-multiaddr"
 )
 
 var (
@@ -63,9 +61,7 @@ func TestManager_GetStore(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "")
 	checkErr(t, err)
-	addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
-	checkErr(t, err)
-	ts, err := DefaultThreadservice(dir, HostProxyAddr(addr))
+	ts, err := DefaultThreadservice(dir)
 	checkErr(t, err)
 	man, err := NewManager(ts, WithRepoPath(dir), WithJsonMode(true), WithDebug(true))
 	checkErr(t, err)
@@ -98,9 +94,7 @@ func TestManager_GetStore(t *testing.T) {
 	checkErr(t, err)
 
 	t.Run("GetHydrated", func(t *testing.T) {
-		addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
-		checkErr(t, err)
-		ts, err := DefaultThreadservice(dir, HostProxyAddr(addr))
+		ts, err := DefaultThreadservice(dir)
 		checkErr(t, err)
 		man, err := NewManager(ts, WithRepoPath(dir), WithJsonMode(true), WithDebug(true))
 		checkErr(t, err)
@@ -132,9 +126,7 @@ func TestManager_GetStore(t *testing.T) {
 func createTestManager(t *testing.T) (*Manager, func()) {
 	dir, err := ioutil.TempDir("", "")
 	checkErr(t, err)
-	addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
-	checkErr(t, err)
-	ts, err := DefaultThreadservice(dir, HostProxyAddr(addr))
+	ts, err := DefaultThreadservice(dir)
 	checkErr(t, err)
 	m, err := NewManager(ts, WithRepoPath(dir), WithJsonMode(true), WithDebug(true))
 	checkErr(t, err)

--- a/eventstore/model_test.go
+++ b/eventstore/model_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	logging "github.com/ipfs/go-log"
+	ma "github.com/multiformats/go-multiaddr"
 	core "github.com/textileio/go-textile-core/store"
 )
 
@@ -31,7 +32,7 @@ type Comment struct {
 }
 
 func TestMain(m *testing.M) {
-	logging.SetLogLevel("*", "error")
+	_ = logging.SetLogLevel("*", "error")
 	os.Exit(m.Run())
 }
 
@@ -254,7 +255,7 @@ func TestGetInstance(t *testing.T) {
 	t.Run("WithReadTx", func(t *testing.T) {
 		person := &Person{}
 		err = model.ReadTxn(func(txn *Txn) error {
-			txn.FindByID(newPerson.ID, person)
+			_ = txn.FindByID(newPerson.ID, person)
 			checkErr(t, err)
 			if !reflect.DeepEqual(newPerson, person) {
 				t.Fatalf(errInvalidInstanceState)
@@ -265,7 +266,7 @@ func TestGetInstance(t *testing.T) {
 	t.Run("WithUpdateTx", func(t *testing.T) {
 		person := &Person{}
 		err = model.WriteTxn(func(txn *Txn) error {
-			txn.FindByID(newPerson.ID, person)
+			_ = txn.FindByID(newPerson.ID, person)
 			checkErr(t, err)
 			if !reflect.DeepEqual(newPerson, person) {
 				t.Fatalf(errInvalidInstanceState)
@@ -372,7 +373,7 @@ func TestInvalidActions(t *testing.T) {
 	})
 	t.Run("Save", func(t *testing.T) {
 		p := &PersonFake{Name: "fake"}
-		model.Create(p)
+		_ = model.Create(p)
 		if err := model.Save(p); !errors.Is(err, ErrInvalidSchemaInstance) {
 			t.Fatalf("instance should be invalid compared to schema, got: %v", err)
 		}
@@ -399,7 +400,9 @@ func assertPersonInModel(t *testing.T, model *Model, person *Person) {
 func createTestStore(t *testing.T, opts ...StoreOption) (*Store, func()) {
 	dir, err := ioutil.TempDir("", "")
 	checkErr(t, err)
-	ts, err := DefaultThreadservice(dir, ProxyPort(0))
+	addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
+	checkErr(t, err)
+	ts, err := DefaultThreadservice(dir, HostProxyAddr(addr))
 	checkErr(t, err)
 	opts = append(opts, WithRepoPath(dir))
 	s, err := NewStore(ts, opts...)
@@ -408,6 +411,6 @@ func createTestStore(t *testing.T, opts ...StoreOption) (*Store, func()) {
 		if err := ts.Close(); err != nil {
 			panic(err)
 		}
-		os.RemoveAll(dir)
+		_ = os.RemoveAll(dir)
 	}
 }

--- a/eventstore/query_jsonmode_test.go
+++ b/eventstore/query_jsonmode_test.go
@@ -93,193 +93,193 @@ var (
 
 	jsonQueries = []jsonQueryTest{
 		// Ands string
-		jsonQueryTest{
+		{
 			name:   "EqByTitle1",
 			resIdx: []int{0},
 			query:  JSONWhere("Title").Eq(&title0),
 		},
-		jsonQueryTest{
+		{
 			name:   "NeByTitle1",
 			resIdx: []int{1, 2, 3},
 			query:  JSONWhere("Title").Ne(&title0),
 		},
-		jsonQueryTest{
+		{
 			name:   "NeByTitle",
 			resIdx: []int{0, 1, 2, 3},
 			query:  JSONWhere("Title").Ne(&title),
 		},
-		jsonQueryTest{
+		{
 			name:   "EqByTitle",
 			resIdx: []int{},
 			query:  JSONWhere("Title").Eq(&title),
 		},
-		jsonQueryTest{
+		{
 			name:   "LtByTitle",
 			resIdx: []int{},
 			query:  JSONWhere("Title").Lt(&title),
 		},
-		jsonQueryTest{
+		{
 			name:   "GtByTitle",
 			resIdx: []int{0, 1, 2, 3},
 			query:  JSONWhere("Title").Gt(&title),
 		},
-		jsonQueryTest{
+		{
 			name:   "GtByTitleMax",
 			resIdx: []int{},
 			query:  JSONWhere("Title").Gt(&titleMax),
 		},
 
 		// Ands "int" (which query interpret as float)
-		jsonQueryTest{
+		{
 			name:   "EqByTotalReads1",
 			resIdx: []int{0},
 			query:  JSONWhere("Meta.TotalReads").Eq(&totreadEq1),
 		},
-		jsonQueryTest{
+		{
 			name:   "LtByTotalReads1",
 			resIdx: []int{},
 			query:  JSONWhere("Meta.TotalReads").Lt(&totreadEq1),
 		},
-		jsonQueryTest{
+		{
 			name:   "LeByTotalReadsBigger",
 			resIdx: []int{0, 1, 2, 3},
 			query:  JSONWhere("Meta.TotalReads").Le(&totreadMax),
 		},
-		jsonQueryTest{
+		{
 			name:   "GeByTotalReadsMin",
 			resIdx: []int{0, 1, 2, 3},
 			query:  JSONWhere("Meta.TotalReads").Ge(&totreadMin),
 		},
-		jsonQueryTest{
+		{
 			name:   "LtByTotalReadsMidpoint",
 			resIdx: []int{0, 2},
 			query:  JSONWhere("Meta.TotalReads").Lt(&totreadMid),
 		},
-		jsonQueryTest{
+		{
 			name:   "GtByTotalReadsMidpoint",
 			resIdx: []int{1, 3},
 			query:  JSONWhere("Meta.TotalReads").Gt(&totreadMid),
 		},
-		jsonQueryTest{
+		{
 			name:   "LtByTotalReads2",
 			resIdx: []int{0, 2},
 			query:  JSONWhere("Meta.TotalReads").Lt(&totreadEq2),
 		},
 
 		// Ands float
-		jsonQueryTest{
+		{
 			name:   "EqByRating1",
 			resIdx: []int{0},
 			query:  JSONWhere("Meta.Rating").Eq(&rating1),
 		},
-		jsonQueryTest{
+		{
 			name:   "GtByRating1",
 			resIdx: []int{1, 2},
 			query:  JSONWhere("Meta.Rating").Gt(&rating1),
 		},
-		jsonQueryTest{
+		{
 			name:   "LeByRatingMin",
 			resIdx: []int{},
 			query:  JSONWhere("Meta.Rating").Le(&ratingMin),
 		},
-		jsonQueryTest{
+		{
 			name:   "GeByRatingMin",
 			resIdx: []int{0, 1, 2, 3},
 			query:  JSONWhere("Meta.Rating").Ge(&ratingMin),
 		},
-		jsonQueryTest{
+		{
 			name:   "LeByRatingMid",
 			resIdx: []int{0, 3},
 			query:  JSONWhere("Meta.Rating").Le(&ratingMid),
 		},
-		jsonQueryTest{
+		{
 			name:   "GeByRatingMid",
 			resIdx: []int{1, 2},
 			query:  JSONWhere("Meta.Rating").Ge(&ratingMid),
 		},
-		jsonQueryTest{
+		{
 			name:   "LeByRatingMax",
 			resIdx: []int{0, 1, 2, 3},
 			query:  JSONWhere("Meta.Rating").Le(&ratingMax),
 		},
-		jsonQueryTest{
+		{
 			name:   "GtByRatingMax",
 			resIdx: []int{},
 			query:  JSONWhere("Meta.Rating").Gt(&ratingMax),
 		},
 		// Ands bool
-		jsonQueryTest{
+		{
 			name:   "EqByBanned",
 			resIdx: []int{0, 3},
 			query:  JSONWhere("Banned").Eq(&boolTrue),
 		},
-		jsonQueryTest{
+		{
 			name:   "NeByBanned",
 			resIdx: []int{1, 2},
 			query:  JSONWhere("Banned").Ne(&boolTrue),
 		},
-		jsonQueryTest{
+		{
 			name:   "EqByBannedFalse",
 			resIdx: []int{1, 2},
 			query:  JSONWhere("Banned").Eq(&boolFalse),
 		},
 
 		// Ors
-		jsonQueryTest{
+		{
 			name:   "EqTitle1OrTitle3",
 			resIdx: []int{0, 2},
 			query:  JSONWhere("Title").Eq(&title0).JSONOr(JSONWhere("Title").Eq(&title3)),
 		},
-		jsonQueryTest{
+		{
 			name:   "EqTitle2OrRating",
 			resIdx: []int{0, 1},
 			query:  JSONWhere("Title").Eq(&title1).JSONOr(JSONWhere("Meta.Rating").Eq(&rating1)),
 		},
 
 		// Ordering (string, int, float)
-		jsonQueryTest{
+		{
 			name:    "AllOrderedTitle",
 			resIdx:  []int{0, 1, 2, 3},
 			query:   JSONOrderBy("Title"),
 			ordered: true,
 		},
-		jsonQueryTest{
+		{
 			name:    "AllOrderedTitleDesc",
 			resIdx:  []int{3, 2, 1, 0},
 			query:   JSONOrderByDesc("Title"),
 			ordered: true,
 		},
-		jsonQueryTest{
+		{
 			name:    "AllOrderedTotalReads",
 			resIdx:  []int{0, 2, 1, 3},
 			query:   JSONOrderBy("Meta.TotalReads"),
 			ordered: true,
 		},
-		jsonQueryTest{
+		{
 			name:    "AllOrderedTotalReads",
 			resIdx:  []int{3, 1, 2, 0},
 			query:   JSONOrderByDesc("Meta.TotalReads"),
 			ordered: true,
 		},
-		jsonQueryTest{
+		{
 			name:    "AllOrderedRatings",
 			resIdx:  []int{3, 0, 1, 2},
 			query:   JSONOrderBy("Meta.Rating"),
 			ordered: true,
 		},
-		jsonQueryTest{
+		{
 			name:    "AllOrderedRatingsDesc",
 			resIdx:  []int{2, 1, 0, 3},
 			query:   JSONOrderByDesc("Meta.Rating"),
 			ordered: true,
 		},
-		jsonQueryTest{
+		{
 			name:    "AllOrderedRatingsDescWithAnd",
 			resIdx:  []int{2, 1},
 			query:   JSONWhere("Meta.Rating").Gt(&ratingMid).JSONOrderBy("Meta.TotalReads"),
 			ordered: true,
 		},
-		jsonQueryTest{
+		{
 			name:    "AllOrderedRatingsDescWithAndDesc",
 			resIdx:  []int{1, 2},
 			query:   JSONWhere("Meta.Rating").Gt(&ratingMid).JSONOrderByDesc("Meta.TotalReads"),

--- a/eventstore/store_test.go
+++ b/eventstore/store_test.go
@@ -10,7 +10,6 @@ import (
 	ds "github.com/ipfs/go-datastore"
 	ipldformat "github.com/ipfs/go-ipld-format"
 	"github.com/multiformats/go-multiaddr"
-	ma "github.com/multiformats/go-multiaddr"
 	core "github.com/textileio/go-textile-core/store"
 )
 
@@ -22,9 +21,7 @@ func TestE2EWithThreads(t *testing.T) {
 	checkErr(t, err)
 	defer os.RemoveAll(tmpDir1)
 
-	addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
-	checkErr(t, err)
-	ts1, err := DefaultThreadservice(tmpDir1, HostProxyAddr(addr))
+	ts1, err := DefaultThreadservice(tmpDir1)
 	checkErr(t, err)
 	defer ts1.Close()
 
@@ -57,9 +54,7 @@ func TestE2EWithThreads(t *testing.T) {
 	tmpDir2, err := ioutil.TempDir("", "")
 	checkErr(t, err)
 	defer os.RemoveAll(tmpDir2)
-	addr2, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
-	checkErr(t, err)
-	ts2, err := DefaultThreadservice(tmpDir2, HostProxyAddr(addr2))
+	ts2, err := DefaultThreadservice(tmpDir2)
 	checkErr(t, err)
 	defer ts2.Close()
 
@@ -85,9 +80,7 @@ func TestOptions(t *testing.T) {
 	checkErr(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
-	checkErr(t, err)
-	ts, err := DefaultThreadservice(tmpDir, HostProxyAddr(addr))
+	ts, err := DefaultThreadservice(tmpDir)
 	checkErr(t, err)
 
 	ec := &mockEventCodec{}
@@ -107,9 +100,7 @@ func TestOptions(t *testing.T) {
 	checkErr(t, s.Close())
 
 	time.Sleep(time.Second * 3)
-	addr2, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
-	checkErr(t, err)
-	ts, err = DefaultThreadservice(tmpDir, HostProxyAddr(addr2))
+	ts, err = DefaultThreadservice(tmpDir)
 	checkErr(t, err)
 	defer ts.Close()
 	s, err = NewStore(ts, WithRepoPath(tmpDir), WithEventCodec(ec))

--- a/eventstore/util.go
+++ b/eventstore/util.go
@@ -2,7 +2,6 @@ package eventstore
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -13,8 +12,8 @@ import (
 	connmgr "github.com/libp2p/go-libp2p-connmgr"
 	host "github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
-	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p-core/peerstore"
+	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p-peerstore/pstoreds"
 	ma "github.com/multiformats/go-multiaddr"
 	tserv "github.com/textileio/go-textile-core/threadservice"
@@ -24,8 +23,7 @@ import (
 )
 
 const (
-	defaultIpfsLitePath  = "ipfslite"
-	defaultListeningPort = 5002
+	defaultIpfsLitePath = "ipfslite"
 )
 
 // DefaultThreadService is a boostrapable default Threadservice with
@@ -37,11 +35,19 @@ type ThreadserviceBoostrapper interface {
 }
 
 func DefaultThreadservice(repoPath string, opts ...Option) (ThreadserviceBoostrapper, error) {
-	config := &Config{ProxyPort: 5050}
+	config := &Config{}
 	for _, opt := range opts {
 		if err := opt(config); err != nil {
 			return nil, err
 		}
+	}
+
+	if config.HostAddr == nil {
+		addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
+		if err != nil {
+			return nil, err
+		}
+		config.HostAddr = addr
 	}
 
 	ipfsLitePath := filepath.Join(repoPath, defaultIpfsLitePath)
@@ -60,18 +66,12 @@ func DefaultThreadservice(repoPath string, opts ...Option) (ThreadserviceBoostra
 		cancel()
 		return nil, err
 	}
-	listen, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", config.ListenPort))
-	if err != nil {
-		ds.Close()
-		cancel()
-		return nil, err
-	}
 	priv := util.LoadKey(filepath.Join(ipfsLitePath, "key"))
-	h, dht, err := ipfslite.SetupLibp2p(
+	h, d, err := ipfslite.SetupLibp2p(
 		ctx,
 		priv,
 		nil,
-		[]ma.Multiaddr{listen},
+		[]ma.Multiaddr{config.HostAddr},
 		libp2p.ConnectionManager(connmgr.NewConnManager(100, 400, time.Minute)),
 		libp2p.Peerstore(pstore),
 	)
@@ -81,7 +81,7 @@ func DefaultThreadservice(repoPath string, opts ...Option) (ThreadserviceBoostra
 		return nil, err
 	}
 
-	lite, err := ipfslite.New(ctx, ds, h, dht, nil)
+	lite, err := ipfslite.New(ctx, ds, h, d, nil)
 	if err != nil {
 		cancel()
 		ds.Close()
@@ -99,7 +99,7 @@ func DefaultThreadservice(repoPath string, opts ...Option) (ThreadserviceBoostra
 	// Build a threadservice
 	api, err := t.NewThreads(ctx, h, lite.BlockStore(), lite, tstore, t.Config{
 		Debug:     config.Debug,
-		ProxyAddr: fmt.Sprintf("0.0.0.0:%d", config.ProxyPort),
+		ProxyAddr: config.HostProxyAddr,
 	})
 	if err != nil {
 		cancel()
@@ -114,28 +114,28 @@ func DefaultThreadservice(repoPath string, opts ...Option) (ThreadserviceBoostra
 		pstore:        pstore,
 		ds:            ds,
 		host:          h,
-		dht:           dht,
+		dht:           d,
 	}, nil
 }
 
 type Config struct {
-	ListenPort int
-	ProxyPort  int
-	Debug      bool
+	HostAddr      ma.Multiaddr
+	HostProxyAddr ma.Multiaddr
+	Debug         bool
 }
 
 type Option func(c *Config) error
 
-func ListenPort(port int) Option {
+func HostAddr(addr ma.Multiaddr) Option {
 	return func(c *Config) error {
-		c.ListenPort = port
+		c.HostAddr = addr
 		return nil
 	}
 }
 
-func ProxyPort(port int) Option {
+func HostProxyAddr(addr ma.Multiaddr) Option {
 	return func(c *Config) error {
-		c.ProxyPort = port
+		c.HostProxyAddr = addr
 		return nil
 	}
 }

--- a/eventstore/util.go
+++ b/eventstore/util.go
@@ -49,6 +49,13 @@ func DefaultThreadservice(repoPath string, opts ...Option) (ThreadserviceBoostra
 		}
 		config.HostAddr = addr
 	}
+	if config.HostProxyAddr == nil {
+		addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
+		if err != nil {
+			return nil, err
+		}
+		config.HostProxyAddr = addr
+	}
 
 	ipfsLitePath := filepath.Join(repoPath, defaultIpfsLitePath)
 	if err := os.MkdirAll(ipfsLitePath, os.ModePerm); err != nil {

--- a/examples/e2e_counter/main.go
+++ b/examples/e2e_counter/main.go
@@ -11,7 +11,6 @@ import (
 func main() {
 	writer := flag.Bool("writer", false, "peer role")
 	repo := flag.String("repo", ".thread", "repo path for the store")
-	port := flag.Int("port", 5000, "porto to listen to")
 	clean := flag.Bool("clean", true, "deletes any previous state. a fresh start")
 	flag.Parse()
 
@@ -28,8 +27,8 @@ func main() {
 	util.SetupDefaultLoggingConfig(*repo)
 	// Run different things depending on flag
 	if *writer {
-		runWriterPeer(*repo, *port)
+		runWriterPeer(*repo)
 	} else {
-		runReaderPeer(*repo, *port)
+		runReaderPeer(*repo)
 	}
 }

--- a/examples/e2e_counter/reader.go
+++ b/examples/e2e_counter/reader.go
@@ -15,9 +15,7 @@ func runReaderPeer(repo string) {
 	fmt.Printf("I'm a model reader.\n")
 	writerAddr, fkey, rkey := getWriterAddr()
 
-	addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
-	checkErr(err)
-	ts, err := es.DefaultThreadservice(repo, es.HostProxyAddr(addr))
+	ts, err := es.DefaultThreadservice(repo)
 	checkErr(err)
 	defer ts.Close()
 	store, err := es.NewStore(ts, es.WithRepoPath(repo))

--- a/examples/e2e_counter/reader.go
+++ b/examples/e2e_counter/reader.go
@@ -11,11 +11,13 @@ import (
 	es "github.com/textileio/go-textile-threads/eventstore"
 )
 
-func runReaderPeer(repo string, port int) {
+func runReaderPeer(repo string) {
 	fmt.Printf("I'm a model reader.\n")
 	writerAddr, fkey, rkey := getWriterAddr()
 
-	ts, err := es.DefaultThreadservice(repo, es.ProxyPort(0))
+	addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
+	checkErr(err)
+	ts, err := es.DefaultThreadservice(repo, es.HostProxyAddr(addr))
 	checkErr(err)
 	defer ts.Close()
 	store, err := es.NewStore(ts, es.WithRepoPath(repo))

--- a/examples/e2e_counter/writer.go
+++ b/examples/e2e_counter/writer.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/mr-tron/base58"
 	"github.com/multiformats/go-multiaddr"
-	ma "github.com/multiformats/go-multiaddr"
 	core "github.com/textileio/go-textile-core/store"
 	"github.com/textileio/go-textile-core/thread"
 	es "github.com/textileio/go-textile-threads/eventstore"
@@ -22,9 +21,7 @@ type myCounter struct {
 func runWriterPeer(repo string) {
 	fmt.Printf("I'm a writer\n")
 
-	addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
-	checkErr(err)
-	ts, err := es.DefaultThreadservice(repo, es.HostProxyAddr(addr))
+	ts, err := es.DefaultThreadservice(repo)
 	checkErr(err)
 	defer ts.Close()
 	store, err := es.NewStore(ts, es.WithRepoPath(repo))

--- a/examples/local_eventstore/books/main.go
+++ b/examples/local_eventstore/books/main.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	ma "github.com/multiformats/go-multiaddr"
 	core "github.com/textileio/go-textile-core/store"
 	es "github.com/textileio/go-textile-threads/eventstore"
 )
@@ -153,9 +152,7 @@ func main() {
 func createMemStore() (*es.Store, func()) {
 	dir, err := ioutil.TempDir("", "")
 	checkErr(err)
-	addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
-	checkErr(err)
-	ts, err := es.DefaultThreadservice(dir, es.HostProxyAddr(addr))
+	ts, err := es.DefaultThreadservice(dir)
 	checkErr(err)
 	s, err := es.NewStore(ts, es.WithRepoPath(dir))
 	checkErr(err)

--- a/examples/local_eventstore/books/main.go
+++ b/examples/local_eventstore/books/main.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	ma "github.com/multiformats/go-multiaddr"
 	core "github.com/textileio/go-textile-core/store"
 	es "github.com/textileio/go-textile-threads/eventstore"
 )
@@ -127,7 +128,7 @@ func main() {
 		// Modify title
 		book := books[0]
 		book.Title = "ModifiedTitle"
-		model.Save(book)
+		_ = model.Save(book)
 		err = model.Find(&books, es.Where("Title").Eq("Title3"))
 		checkErr(err)
 		if len(books) != 0 {
@@ -140,7 +141,7 @@ func main() {
 		if len(books) != 1 {
 			panic("Book with ModifiedTitle should exist")
 		}
-		model.Delete(books[0].ID)
+		_ = model.Delete(books[0].ID)
 		err = model.Find(&books, es.Where("Title").Eq("ModifiedTitle"))
 		checkErr(err)
 		if len(books) != 0 {
@@ -152,7 +153,9 @@ func main() {
 func createMemStore() (*es.Store, func()) {
 	dir, err := ioutil.TempDir("", "")
 	checkErr(err)
-	ts, err := es.DefaultThreadservice(dir, es.ProxyPort(0))
+	addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
+	checkErr(err)
+	ts, err := es.DefaultThreadservice(dir, es.HostProxyAddr(addr))
 	checkErr(err)
 	s, err := es.NewStore(ts, es.WithRepoPath(dir))
 	checkErr(err)
@@ -160,7 +163,7 @@ func createMemStore() (*es.Store, func()) {
 		if err := ts.Close(); err != nil {
 			panic(err)
 		}
-		os.RemoveAll(dir)
+		_ = os.RemoveAll(dir)
 	}
 }
 

--- a/examples/local_eventstore/json-books/main.go
+++ b/examples/local_eventstore/json-books/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	ma "github.com/multiformats/go-multiaddr"
 	"github.com/textileio/go-textile-core/store"
 	es "github.com/textileio/go-textile-threads/eventstore"
 )
@@ -114,7 +115,9 @@ func main() {
 func createJsonModeMemStore() (*es.Store, func()) {
 	dir, err := ioutil.TempDir("", "")
 	checkErr(err)
-	ts, err := es.DefaultThreadservice(dir, es.ProxyPort(0))
+	addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
+	checkErr(err)
+	ts, err := es.DefaultThreadservice(dir, es.HostProxyAddr(addr))
 	checkErr(err)
 	s, err := es.NewStore(ts, es.WithRepoPath(dir), es.WithJsonMode(true))
 	checkErr(err)
@@ -122,7 +125,7 @@ func createJsonModeMemStore() (*es.Store, func()) {
 		if err := ts.Close(); err != nil {
 			panic(err)
 		}
-		os.RemoveAll(dir)
+		_ = os.RemoveAll(dir)
 	}
 }
 

--- a/examples/local_eventstore/json-books/main.go
+++ b/examples/local_eventstore/json-books/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 
-	ma "github.com/multiformats/go-multiaddr"
 	"github.com/textileio/go-textile-core/store"
 	es "github.com/textileio/go-textile-threads/eventstore"
 )
@@ -115,9 +114,7 @@ func main() {
 func createJsonModeMemStore() (*es.Store, func()) {
 	dir, err := ioutil.TempDir("", "")
 	checkErr(err)
-	addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
-	checkErr(err)
-	ts, err := es.DefaultThreadservice(dir, es.HostProxyAddr(addr))
+	ts, err := es.DefaultThreadservice(dir)
 	checkErr(err)
 	s, err := es.NewStore(ts, es.WithRepoPath(dir), es.WithJsonMode(true))
 	checkErr(err)

--- a/test/threads_suite.go
+++ b/test/threads_suite.go
@@ -35,10 +35,12 @@ var threadsSuite = []map[string]func(tserv.Threadservice, tserv.Threadservice) f
 
 func ThreadsTest(t *testing.T) {
 	// Create two thread services.
-	m1, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/4006")
-	ts1 := newService(t, m1, "127.0.0.1:5050")
-	m2, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/4007")
-	ts2 := newService(t, m2, "127.0.0.1:5051")
+	h1, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/4006")
+	hp1, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/5050")
+	ts1 := newService(t, h1, hp1)
+	h2, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/4007")
+	hp2, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/5051")
+	ts2 := newService(t, h2, hp2)
 
 	ts1.Host().Peerstore().AddAddrs(ts2.Host().ID(), ts2.Host().Addrs(), peerstore.PermanentAddrTTL)
 	ts2.Host().Peerstore().AddAddrs(ts1.Host().ID(), ts1.Host().Addrs(), peerstore.PermanentAddrTTL)
@@ -51,12 +53,12 @@ func ThreadsTest(t *testing.T) {
 	}
 }
 
-func newService(t *testing.T, listen ma.Multiaddr, proxyAddr string) tserv.Threadservice {
+func newService(t *testing.T, hostAddr ma.Multiaddr, hostProxyAddr ma.Multiaddr) tserv.Threadservice {
 	sk, _, err := ic.GenerateKeyPair(ic.Ed25519, 0)
 	check(t, err)
 	host, err := libp2p.New(
 		context.Background(),
-		libp2p.ListenAddrs(listen),
+		libp2p.ListenAddrs(hostAddr),
 		libp2p.Identity(sk),
 	)
 	check(t, err)
@@ -69,7 +71,7 @@ func newService(t *testing.T, listen ma.Multiaddr, proxyAddr string) tserv.Threa
 		bsrv.Blockstore(),
 		dag.NewDAGService(bsrv),
 		tstore.NewThreadstore(),
-		threads.Config{ProxyAddr: proxyAddr, Debug: true})
+		threads.Config{ProxyAddr: hostProxyAddr, Debug: true})
 	check(t, err)
 	return ts
 }

--- a/threads.go
+++ b/threads.go
@@ -70,7 +70,7 @@ type threads struct {
 
 // Config is used to specify thread instance options.
 type Config struct {
-	ProxyAddr ma.Multiaddr // defaults to /ip4/0.0.0.0/tcp/5050
+	ProxyAddr ma.Multiaddr
 	Debug     bool
 }
 
@@ -122,7 +122,10 @@ func NewThreads(
 
 	// Start a web RPC proxy
 	webrpc := grpcweb.WrapServer(t.rpc)
-	proxyAddr := util.TCPAddrFromMultiAddr(conf.ProxyAddr, "0.0.0.0:5050")
+	proxyAddr, err := util.TCPAddrFromMultiAddr(conf.ProxyAddr)
+	if err != nil {
+		return nil, err
+	}
 	t.proxy = &http.Server{
 		Addr: proxyAddr,
 	}
@@ -149,7 +152,6 @@ func NewThreads(
 		}
 		log.Info("proxy was shutdown")
 	}()
-	log.Infof("proxy listening at %s", t.proxy.Addr)
 
 	go t.startPulling()
 

--- a/threads.go
+++ b/threads.go
@@ -70,7 +70,7 @@ type threads struct {
 
 // Config is used to specify thread instance options.
 type Config struct {
-	ProxyAddr string // defaults to 0.0.0.0:5050
+	ProxyAddr ma.Multiaddr // defaults to /ip4/0.0.0.0/tcp/5050
 	Debug     bool
 }
 
@@ -122,11 +122,9 @@ func NewThreads(
 
 	// Start a web RPC proxy
 	webrpc := grpcweb.WrapServer(t.rpc)
-	if conf.ProxyAddr == "" {
-		conf.ProxyAddr = "0.0.0.0:5050"
-	}
+	proxyAddr := util.TCPAddrFromMultiAddr(conf.ProxyAddr, "0.0.0.0:5050")
 	t.proxy = &http.Server{
-		Addr: conf.ProxyAddr,
+		Addr: proxyAddr,
 	}
 	t.proxy.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if webrpc.IsGrpcWebRequest(r) {

--- a/util/util.go
+++ b/util/util.go
@@ -164,16 +164,6 @@ func DecodeKey(k string) (*sym.Key, error) {
 	return sym.NewKey(b)
 }
 
-// PadArgs returns args with min length l.
-func PadArgs(args []string, l int) []string {
-	if len(args) > l {
-		l = len(args)
-	}
-	padded := make([]string, l)
-	copy(padded, args)
-	return padded
-}
-
 // SetupDefaultLoggingConfig sets up a standard logging configuration.
 func SetupDefaultLoggingConfig(repoPath string) {
 	lj := &lumberjack.Logger{
@@ -253,4 +243,19 @@ func ParseBootstrapPeers(addrs []string) ([]peer.AddrInfo, error) {
 		}
 	}
 	return peer.AddrInfosFromP2pAddrs(maddrs...)
+}
+
+func TCPAddrFromMultiAddr(addr ma.Multiaddr, def string) string {
+	if addr == nil {
+		return def
+	}
+	ip4, err := addr.ValueForProtocol(ma.P_IP4)
+	if err != nil {
+		return def
+	}
+	tcp, err := addr.ValueForProtocol(ma.P_TCP)
+	if err != nil {
+		return def
+	}
+	return fmt.Sprintf("%s:%s", ip4, tcp)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -245,17 +245,18 @@ func ParseBootstrapPeers(addrs []string) ([]peer.AddrInfo, error) {
 	return peer.AddrInfosFromP2pAddrs(maddrs...)
 }
 
-func TCPAddrFromMultiAddr(addr ma.Multiaddr, def string) string {
-	if addr == nil {
-		return def
+func TCPAddrFromMultiAddr(maddr ma.Multiaddr) (addr string, err error) {
+	if maddr == nil {
+		err = fmt.Errorf("invalid address")
+		return
 	}
-	ip4, err := addr.ValueForProtocol(ma.P_IP4)
+	ip4, err := maddr.ValueForProtocol(ma.P_IP4)
 	if err != nil {
-		return def
+		return
 	}
-	tcp, err := addr.ValueForProtocol(ma.P_TCP)
+	tcp, err := maddr.ValueForProtocol(ma.P_TCP)
 	if err != nil {
-		return def
+		return
 	}
-	return fmt.Sprintf("%s:%s", ip4, tcp)
+	return fmt.Sprintf("%s:%s", ip4, tcp), nil
 }


### PR DESCRIPTION
From working on daemon + CLI, it's ugly to mix multi addresses w/ normal TCP addresses. This just enforces that all things are multi. 